### PR TITLE
Fix config env default

### DIFF
--- a/config.py
+++ b/config.py
@@ -32,7 +32,9 @@ class Config:
     SESSION_COOKIE_HTTPONLY: bool = True
     SESSION_COOKIE_SAMESITE: str = "Lax"
     PERMANENT_SESSION_LIFETIME: timedelta = timedelta(
-        minutes=get_env_int("SESSION_LIFETIME_MINUTES", default=60)
+        minutes=get_env_int(
+            "SESSION_LIFETIME_MINUTES", required=False, default=60
+        )
     )
     WTF_CSRF_ENABLED: bool = True
 


### PR DESCRIPTION
## Summary
- allow Config.PERMANENT_SESSION_LIFETIME to use the default when `SESSION_LIFETIME_MINUTES` is unset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ea333ac0832485793c36a62bceca