### PR TITLE
Fix login redirect to Discord

### DIFF
--- a/blueprints/public_routes.py
+++ b/blueprints/public_routes.py
@@ -4,7 +4,18 @@ public_routes.py – Flask Blueprint für alle öffentlichen Views
 Stellt alle öffentlichen Seiten bereit (ohne Login/Role), z.B. Landing Page, Login, Lore, Events, Leaderboards.
 """
 
-from flask import Blueprint, render_template
+from flask import (
+    Blueprint,
+    render_template,
+    redirect,
+    url_for,
+    request,
+    flash,
+    current_app,
+    session,
+)
+from urllib.parse import urlencode
+import requests
 
 public_bp = Blueprint("public", __name__)
 
@@ -21,6 +32,70 @@ def login():
     Login-Seite (öffentlich).
     """
     return render_template("public/login.html")
+
+@public_bp.route("/login/discord")
+def discord_login():
+    """Startet den OAuth-Login bei Discord."""
+    client_id = current_app.config.get("DISCORD_CLIENT_ID")
+    redirect_uri = current_app.config.get("DISCORD_REDIRECT_URI")
+    if not client_id or not redirect_uri:
+        flash("Discord OAuth nicht konfiguriert", "danger")
+        return redirect(url_for("public.login"))
+
+    params = {
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "response_type": "code",
+        "scope": "identify",
+    }
+    url = f"https://discord.com/oauth2/authorize?{urlencode(params)}"
+    return redirect(url)
+
+@public_bp.route("/login/discord/callback")
+def discord_callback():
+    """Callback-URL für den Discord-OAuth-Login."""
+    code = request.args.get("code")
+    if not code:
+        flash("Discord Login fehlgeschlagen", "danger")
+        return redirect(url_for("public.login"))
+
+    try:
+        token_resp = requests.post(
+            "https://discord.com/api/oauth2/token",
+            data={
+                "client_id": current_app.config.get("DISCORD_CLIENT_ID"),
+                "client_secret": current_app.config.get("DISCORD_CLIENT_SECRET"),
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": current_app.config.get("DISCORD_REDIRECT_URI"),
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=10,
+        )
+        token_resp.raise_for_status()
+        access_token = token_resp.json().get("access_token")
+    except Exception as e:
+        current_app.logger.error(f"Discord Token Error: {e}")
+        flash("Discord Login fehlgeschlagen", "danger")
+        return redirect(url_for("public.login"))
+
+    try:
+        user_resp = requests.get(
+            "https://discord.com/api/users/@me",
+            headers={"Authorization": f"Bearer {access_token}"},
+            timeout=10,
+        )
+        user_resp.raise_for_status()
+        user = user_resp.json()
+    except Exception as e:
+        current_app.logger.error(f"Discord User Error: {e}")
+        flash("Discord Login fehlgeschlagen", "danger")
+        return redirect(url_for("public.login"))
+
+    session["discord_user_id"] = user["id"]
+    session["discord_username"] = user.get("username")
+    flash("Erfolgreich mit Discord eingeloggt", "success")
+    return redirect(url_for("public.landing"))
 
 @public_bp.route("/lore")
 def lore():

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,5 +3,5 @@
 {% block content %}
   <h1>🐺 {{ _('Willkommen bei System by FUR') }}</h1>
   <p>{{ _('Das zentrale Portal für Events, Auszeichnungen und Ruhm.') }}</p>
-  <a class="btn" href="{{ url_for('public.login') }}">{{ _('Login mit Discord') }}</a>
+  <a class="btn" href="{{ url_for('public.discord_login') }}">{{ _('Login mit Discord') }}</a>
 {% endblock %}

--- a/templates/public/landing.html
+++ b/templates/public/landing.html
@@ -7,6 +7,6 @@
     <img src="{{ url_for('static', filename='img/logo.png') }}" alt="FUR Logo" style="max-width:200px; margin-bottom: 1em;">
     <h1>🐺 {{ t("welcome_message") }}</h1>
     <p>{{ t("portal_intro") }}</p>
-    <a class="btn" href="{{ url_for('public.login') }}">{{ t("login_with_discord") }}</a>
+    <a class="btn" href="{{ url_for('public.discord_login') }}">{{ t("login_with_discord") }}</a>
   </div>
 {% endblock %}

--- a/templates/public/login.html
+++ b/templates/public/login.html
@@ -2,5 +2,5 @@
 {% block title %}{{ t("login_title") }}{% endblock %}
 {% block content %}
   <h2>{{ t("login_required") }}</h2>
-  <a class="btn" href="{{ url_for('public.login') }}">{{ t("login_with_discord") }}</a>
+  <a class="btn" href="{{ url_for('public.discord_login') }}">{{ t("login_with_discord") }}</a>
 {% endblock %}


### PR DESCRIPTION
## Summary
- implement OAuth flow for Discord on active routes
- update imports accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846699f3f148324a100514599f2cd5f