### PR TITLE
Add fallback /callback route

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -20,6 +20,8 @@ export DISCORD_CHANNEL_ID=1
 export DISCORD_CLIENT_ID=<client id>
 export DISCORD_CLIENT_SECRET=<client secret>
 export DISCORD_REDIRECT_URI=http://localhost:8080/login/discord/callback
+# Alternativ kann auch die Kurz-URL
+# http://localhost:8080/callback verwendet werden
 ```
 
 3. Anwendung starten:

--- a/blueprints/public_routes.py
+++ b/blueprints/public_routes.py
@@ -19,6 +19,7 @@ import requests
 
 public_bp = Blueprint("public", __name__)
 
+
 @public_bp.route("/")
 def landing():
     """
@@ -26,12 +27,14 @@ def landing():
     """
     return render_template("public/landing.html")
 
+
 @public_bp.route("/login")
 def login():
     """
     Login-Seite (öffentlich).
     """
     return render_template("public/login.html")
+
 
 @public_bp.route("/login/discord")
 def discord_login():
@@ -50,6 +53,7 @@ def discord_login():
     }
     url = f"https://discord.com/oauth2/authorize?{urlencode(params)}"
     return redirect(url)
+
 
 @public_bp.route("/login/discord/callback")
 def discord_callback():
@@ -97,12 +101,21 @@ def discord_callback():
     flash("Erfolgreich mit Discord eingeloggt", "success")
     return redirect(url_for("public.landing"))
 
+
+# Optionale Kurz-URL, falls der OAuth-Redirect ohne Pfad genutzt wird
+@public_bp.route("/callback")
+def callback_alias():
+    """Alias, ruft die eigentliche Discord-OAuth-Callback-Route auf."""
+    return discord_callback()
+
+
 @public_bp.route("/lore")
 def lore():
     """
     Öffentliche Lore-/Story-Seite.
     """
     return render_template("public/lore.html")
+
 
 @public_bp.route("/calendar")
 def calendar():
@@ -111,12 +124,14 @@ def calendar():
     """
     return render_template("public/calendar.html")
 
+
 @public_bp.route("/events_list")
 def events_list():
     """
     Öffentliche Event-Liste.
     """
     return render_template("public/events_list.html")
+
 
 @public_bp.route("/hall_of_fame")
 def hall_of_fame():
@@ -125,12 +140,14 @@ def hall_of_fame():
     """
     return render_template("public/hall_of_fame.html")
 
+
 @public_bp.route("/public_leaderboard")
 def public_leaderboard():
     """
     Öffentliche Leaderboard-Seite.
     """
     return render_template("public/public_leaderboard.html")
+
 
 @public_bp.route("/view_event")
 def view_event():
@@ -147,7 +164,10 @@ def join_event(event_id):
 
     user_id = session["discord_user_id"]
     db = get_db()
-    db.execute("INSERT INTO event_participants (event_id, user_id) VALUES (?, ?)", (event_id, user_id))
+    db.execute(
+        "INSERT INTO event_participants (event_id, user_id) VALUES (?, ?)",
+        (event_id, user_id),
+    )
     db.commit()
     flash(t("you_joined_event"), "success")
     return redirect(url_for("public.view_event", event_id=event_id))

--- a/web/routes/public_routes.py
+++ b/web/routes/public_routes.py
@@ -3,6 +3,7 @@ public_routes.py – Flask Blueprint für alle öffentlichen Views
 
 Stellt alle öffentlichen Seiten bereit (ohne Login/Role), z.B. Landing Page, Login, Lore, Events, Leaderboards.
 """
+
 import os
 from flask import (
     Blueprint,
@@ -21,9 +22,11 @@ from fur_lang.i18n import get_supported_languages
 
 public_bp = Blueprint("public", __name__)
 
+
 @public_bp.route("/")
 def landing():
     return render_template("public/landing.html")
+
 
 @public_bp.route("/set_language")
 def set_language():
@@ -32,10 +35,12 @@ def set_language():
         session["lang"] = lang
     return redirect(request.referrer or url_for("public.landing"))
 
+
 @public_bp.route("/login")
 def login():
     """Login-Seite (öffentlich/Discord)."""
     return render_template("public/login.html")
+
 
 @public_bp.route("/login/discord")
 def discord_login():
@@ -54,6 +59,7 @@ def discord_login():
     }
     url = f"https://discord.com/oauth2/authorize?{urlencode(params)}"
     return redirect(url)
+
 
 @public_bp.route("/login/discord/callback")
 def discord_callback():
@@ -101,15 +107,25 @@ def discord_callback():
     flash("Erfolgreich mit Discord eingeloggt", "success")
     return redirect(url_for("public.landing"))
 
+
+# Optionale Kurz-URL, falls der OAuth-Redirect ohne Pfad genutzt wird
+@public_bp.route("/callback")
+def callback_alias():
+    """Alias, ruft die eigentliche Discord-OAuth-Callback-Route auf."""
+    return discord_callback()
+
+
 @public_bp.route("/lore")
 def lore():
     """Story/Lore-Übersicht."""
     return render_template("public/lore.html")
 
+
 @public_bp.route("/calendar")
 def calendar():
     """Öffentlicher Event-Kalender."""
     return render_template("public/calendar.html")
+
 
 @public_bp.route("/events")
 def events():
@@ -117,32 +133,46 @@ def events():
     # DUMMY-Daten – später mit Datenbank/Logik ersetzen
     events = [
         {"id": 1, "title": "Champion Night", "date": "2025-06-01"},
-        {"id": 2, "title": "Training", "date": "2025-06-10"}
+        {"id": 2, "title": "Training", "date": "2025-06-10"},
     ]
     return render_template("public/events_list.html", events=events)
+
 
 @public_bp.route("/events/<int:event_id>")
 def view_event(event_id):
     """Detailansicht für ein bestimmtes Event."""
     if event_id not in (1, 2):
         abort(404)
-    event = {"id": event_id, "title": f"Event {event_id}", "date": "2025-06-01", "description": "Details folgen..."}
+    event = {
+        "id": event_id,
+        "title": f"Event {event_id}",
+        "date": "2025-06-01",
+        "description": "Details folgen...",
+    }
     return render_template("public/view_event.html", event=event)
+
 
 @public_bp.route("/events/<int:event_id>/join", methods=["POST"])
 def join_event(event_id):
     """Ermöglicht das Beitreten zu einem Event (Dummy, Demo-Logik)."""
     # Beispiel: Session-User in participants eintragen (hier nur Flash-Meldung als Dummy)
     flash("Du bist dem Event erfolgreich beigetreten!", "success")
-    return redirect(url_for('public.view_event', event_id=event_id))
+    return redirect(url_for("public.view_event", event_id=event_id))
+
 
 @public_bp.route("/hall_of_fame")
 def hall_of_fame():
     """Hall of Fame: Champions des Systems."""
     hof = [
-        {"username": "Marcel", "month": "Mai 2025", "honor_title": "PvP-Champion", "poster_url": "/static/champions/champion_testchampion_mai2025.png"},
+        {
+            "username": "Marcel",
+            "month": "Mai 2025",
+            "honor_title": "PvP-Champion",
+            "poster_url": "/static/champions/champion_testchampion_mai2025.png",
+        },
     ]
     return render_template("public/hall_of_fame.html", hof=hof)
+
 
 @public_bp.route("/leaderboard")
 def leaderboard():
@@ -151,7 +181,10 @@ def leaderboard():
         {"rank": 1, "username": "Marcel", "score": 250},
         {"rank": 2, "username": "Neko", "score": 200},
     ]
-    return render_template("public/public_leaderboard.html", leaderboard=leaderboard_data)
+    return render_template(
+        "public/public_leaderboard.html", leaderboard=leaderboard_data
+    )
+
 
 @public_bp.route("/dashboard")
 def dashboard():


### PR DESCRIPTION
## Summary
- register a short `/callback` route that calls the existing Discord OAuth handler
- mention optional callback URL in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846783d85ec83249d8cb000530f1d24