### PR TITLE
Add POST handling for admin create_event

### DIFF
--- a/blueprints/admin_routes.py
+++ b/blueprints/admin_routes.py
@@ -4,7 +4,15 @@ admin_routes.py – Flask Blueprint für Admin-Views (geschützt, R4+)
 Stellt alle Admin-Oberflächen bereit, geschützt durch das r4_required-Decorator (nur Admins/R4).
 """
 
-from flask import Blueprint, render_template
+from flask import (
+    Blueprint,
+    render_template,
+    request,
+    redirect,
+    url_for,
+    flash,
+)
+from init_db_core import get_db_connection
 from web.auth.decorators import r4_required
 
 admin_bp = Blueprint("admin", __name__, url_prefix="/admin")
@@ -26,11 +34,29 @@ def calendar():
     return render_template("admin/calendar.html")
 
 @r4_required
-@admin_bp.route("/create_event")
+@admin_bp.route("/create_event", methods=["GET", "POST"])
 def create_event():
     """
     Event-Erstellung für Admins.
     """
+    if request.method == "POST":
+        title = request.form.get("title")
+        event_time = request.form.get("event_time")
+        description = request.form.get("description")
+
+        try:
+            conn = get_db_connection()
+            conn.execute(
+                "INSERT INTO events (title, event_time, created_by, description) VALUES (?, ?, ?, ?)",
+                (title, event_time, 1, description),
+            )
+            conn.commit()
+            conn.close()
+            flash("Event erstellt", "success")
+            return redirect(url_for("admin.events"))
+        except Exception as e:
+            flash("Fehler beim Speichern", "danger")
+
     return render_template("admin/create_event.html")
 
 @r4_required


### PR DESCRIPTION
## Summary
- allow POST requests on `/create_event` routes
- save submitted event data to SQLite DB and show feedback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684679b806c4832499b72ce54299ac45