### PR TITLE
Enhance Discord login with role checks

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -20,6 +20,10 @@ export DISCORD_CHANNEL_ID=1
 export DISCORD_CLIENT_ID=<client id>
 export DISCORD_CLIENT_SECRET=<client secret>
 export DISCORD_REDIRECT_URI=http://localhost:8080/login/discord/callback
+# Rollen-IDs für Zugriffsebenen (kommasepariert)
+export R3_ROLE_IDS=1234,5678
+export R4_ROLE_IDS=9876
+export ADMIN_ROLE_IDS=1111
 # Alternativ kann auch die Kurz-URL
 # http://localhost:8080/callback verwendet werden
 ```

--- a/config.py
+++ b/config.py
@@ -49,6 +49,11 @@ class Config:
     DISCORD_CLIENT_ID: str | None = get_env_str("DISCORD_CLIENT_ID", required=False)
     DISCORD_CLIENT_SECRET: str | None = get_env_str("DISCORD_CLIENT_SECRET", required=False)
     DISCORD_REDIRECT_URI: str | None = get_env_str("DISCORD_REDIRECT_URI", required=False)
+
+    # --- Discord Role Mapping ---
+    R3_ROLE_IDS: set[str] = set(filter(None, get_env_str("R3_ROLE_IDS", required=False, default="").split(',')))
+    R4_ROLE_IDS: set[str] = set(filter(None, get_env_str("R4_ROLE_IDS", required=False, default="").split(',')))
+    ADMIN_ROLE_IDS: set[str] = set(filter(None, get_env_str("ADMIN_ROLE_IDS", required=False, default="").split(',')))
     
     # BABEL / i18n
     BABEL_DEFAULT_LOCALE = "de"

--- a/web/auth/decorators.py
+++ b/web/auth/decorators.py
@@ -9,57 +9,49 @@ from functools import wraps
 from flask import session, redirect, url_for, flash, abort
 
 def login_required(view_func):
-    """
-    Dekorator: Schützt eine Route, sodass nur eingeloggte User Zugriff haben.
+    """Schützt eine Route für eingeloggte User."""
 
-    Falls der User nicht eingeloggt ist, wird er zur Login-Seite weitergeleitet.
-    """
     @wraps(view_func)
     def wrapper(*args, **kwargs):
-        if "user_id" not in session:
+        if "user" not in session:
             flash("Du musst eingeloggt sein.", "warning")
             return redirect(url_for("public.login"))
         return view_func(*args, **kwargs)
+
     return wrapper
 
 def r3_required(view_func):
-    """
-    Dekorator: Zugriff nur für eingeloggte Member (R3, R4, Owner).
+    """Zugriff nur für Mitglieder (R3+, Admin)."""
 
-    Falls nicht R3 oder höher, Weiterleitung oder 403.
-    """
     @wraps(view_func)
     def wrapper(*args, **kwargs):
-        if "user_id" not in session or session.get("role") not in ("R3", "R4", "ADMIN", "OWNER"):
-            flash("Zugriff nur für eingeloggte Mitglieder.", "warning")
+        if session.get("user", {}).get("role_level") not in ["R3", "R4", "ADMIN"]:
+            flash("Zugriff nur für Mitglieder möglich.")
             return redirect(url_for("public.login"))
         return view_func(*args, **kwargs)
+
     return wrapper
 
 def r4_required(view_func):
-    """
-    Dekorator: Zugriff nur für R4/Admin/Owner.
+    """Zugriff nur für R4 oder Admin."""
 
-    Falls nicht R4/Admin/Owner, Fehler 403.
-    """
     @wraps(view_func)
     def wrapper(*args, **kwargs):
-        if "user_id" not in session or session.get("role") not in ("R4", "ADMIN", "OWNER"):
-            flash("Zugriff nur für Admins.", "danger")
-            return abort(403)
+        if session.get("user", {}).get("role_level") not in ["R4", "ADMIN"]:
+            flash("Nur Admins dürfen diesen Bereich aufrufen.")
+            return redirect(url_for("public.login"))
         return view_func(*args, **kwargs)
+
     return wrapper
 
 def admin_required(view_func):
-    """
-    Dekorator: Zugriff nur für System-Admins/Owner.
+    """Zugriff nur für System-Admins."""
 
-    Falls keine ADMIN/OWNER-Rolle, Fehler 403.
-    """
     @wraps(view_func)
     def wrapper(*args, **kwargs):
-        if "user_id" not in session or session.get("role") not in ("ADMIN", "OWNER"):
-            flash("Zugriff nur für System-Admins.", "danger")
-            return abort(403)
+        if session.get("user", {}).get("role_level") != "ADMIN":
+            flash("Systemzugriff nur für Superuser.")
+            return redirect(url_for("public.login"))
         return view_func(*args, **kwargs)
+
     return wrapper


### PR DESCRIPTION
## Summary
- store role IDs via config
- integrate role-based Discord login flow
- update login decorators for new session format
- document new role env vars in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846864fba4c8324a11c5fc6b2c21fdb