### PR TITLE
Add session check for joining events

### DIFF
--- a/web/routes/public_routes.py
+++ b/web/routes/public_routes.py
@@ -5,20 +5,23 @@ Stellt alle öffentlichen Seiten bereit (ohne Login/Role), z.B. Landing Page, Lo
 """
 
 import os
+from urllib.parse import urlencode
+
+import requests
 from flask import (
     Blueprint,
-    render_template,
+    abort,
     current_app,
+    flash,
+    redirect,
+    render_template,
     request,
     session,
-    redirect,
     url_for,
-    abort,
-    flash,
 )
-from urllib.parse import urlencode
-import requests
+
 from fur_lang.i18n import get_supported_languages
+from web.auth.decorators import r3_required
 
 public_bp = Blueprint("public", __name__)
 
@@ -175,8 +178,13 @@ def view_event(event_id):
 
 
 @public_bp.route("/events/<int:event_id>/join", methods=["POST"])
+@r3_required
 def join_event(event_id):
     """Ermöglicht das Beitreten zu einem Event (Dummy, Demo-Logik)."""
+    if "user" not in session:
+        flash("Du musst eingeloggt sein.", "warning")
+        return redirect(url_for("public.login"))
+
     # Beispiel: Session-User in participants eintragen (hier nur Flash-Meldung als Dummy)
     flash("Du bist dem Event erfolgreich beigetreten!", "success")
     return redirect(url_for("public.view_event", event_id=event_id))


### PR DESCRIPTION
## Summary
- enforce login role for event joining
- verify logged-in user before allowing join

## Testing
- `python3 -m unittest discover` *(fails: DISCORD_TOKEN muss in .env definiert sein)*

------
https://chatgpt.com/codex/tasks/task_e_684713c3f8c88324962411b154872447