### PR TITLE
Expand codex-fur docs and config

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -35,3 +35,17 @@ python main_app.py
 ```
 
 Das Skript `mini.py` ist lediglich für kurze Tests gedacht und lädt keine Blueprints. Für die vollständige Anwendung mit Discord-Login muss `main_app.py` (oder `gunicorn main_app:app`) verwendet werden.
+
+## Codex-FUR Befehle
+
+Das Projekt nutzt [codex-fur](https://github.com/Rabbit-Fur/codex-fur) für Wartungsaufgaben.
+Nach der Installation stehen diese npm-Scripts zur Verfügung:
+
+```bash
+npm run codex:sync     # Übersetzungen synchronisieren
+npm run codex:audit    # Projekt analysieren
+npm run codex:fix      # Automatische Fixes anwenden
+npm run codex:release  # Release-Workflow starten
+```
+
+Die Konfiguration findet sich in `codex-fur.json`.

--- a/codex-fur.json
+++ b/codex-fur.json
@@ -1,0 +1,9 @@
+{
+  "i18nDir": "translations",
+  "scripts": {
+    "sync": "python i18n_tools/translate_sync.py",
+    "audit": "python utils/github_service.py --audit",
+    "fix": "python utils/auto_fixer.py",
+    "release": "python utils/github_service.py --release"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "fur-project",
+  "version": "1.0.0",
+  "scripts": {
+    "codex:sync": "codex-fur sync",
+    "codex:audit": "codex-fur audit",
+    "codex:fix": "codex-fur fix",
+    "codex:release": "codex-fur release"
+  }
+}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,8 @@
+"""Test package initialization for FUR System."""
 
+import os
+
+# Provide default values so configuration imports don't fail during test discovery.
+os.environ.setdefault("DISCORD_TOKEN", "dummy")
+os.environ.setdefault("DISCORD_GUILD_ID", "1")
+os.environ.setdefault("DISCORD_CHANNEL_ID", "1")


### PR DESCRIPTION
## Summary
- document codex-fur usage in README
- add codex-fur.json configuration file for i18n and fix tasks
- configure npm scripts for codex-fur commands
- ensure tests don't fail by default when env vars are missing

## Testing
- `black .`
- `isort . --profile black`
- `python3 -m unittest discover` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68491e9bcdf88324a38d6a6fab11009d