### PR TITLE
Add Dockerfile for Python-based build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "main_app.py"]


### PR DESCRIPTION
## Summary
- add a Dockerfile using python:3.11-slim so `pip install` works

## Testing
- `python3 -m unittest discover` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684a02085b4083248ac189ca00571bf8