### PR TITLE
Improve Discord OAuth state handling

### DIFF
--- a/web/routes/public_routes.py
+++ b/web/routes/public_routes.py
@@ -5,20 +5,12 @@ Stellt alle öffentlichen Seiten bereit (ohne Login/Role), z.B. Landing Page, Lo
 """
 
 import os
+import secrets
 from urllib.parse import urlencode
 
 import requests
-from flask import (
-    Blueprint,
-    abort,
-    current_app,
-    flash,
-    redirect,
-    render_template,
-    request,
-    session,
-    url_for,
-)
+from flask import (Blueprint, abort, current_app, flash, redirect,
+                   render_template, request, session, url_for)
 
 from fur_lang.i18n import get_supported_languages
 from web.auth.decorators import r3_required
@@ -60,6 +52,9 @@ def discord_login():
         "response_type": "code",
         "scope": "identify",
     }
+    state = secrets.token_urlsafe(16)
+    session["discord_oauth_state"] = state
+    params["state"] = state
     url = f"https://discord.com/oauth2/authorize?{urlencode(params)}"
     return redirect(url)
 
@@ -68,8 +63,11 @@ def discord_login():
 def discord_callback():
     """Callback-URL für den Discord-OAuth-Login."""
     code = request.args.get("code")
+    state = request.args.get("state")
     if not code:
         return "Fehlender Code", 400
+    if not state or state != session.pop("discord_oauth_state", None):
+        return "Ungültiger OAuth-State", 400
 
     data = {
         "client_id": current_app.config.get("DISCORD_CLIENT_ID"),
@@ -80,14 +78,17 @@ def discord_callback():
     }
     headers = {"Content-Type": "application/x-www-form-urlencoded"}
     token_response = requests.post(
-        "https://discord.com/api/oauth2/token", data=data, headers=headers
+        "https://discord.com/api/oauth2/token", data=data, headers=headers, timeout=10
     )
 
     if token_response.status_code != 200:
-        return (
-            f"Discord Token Error: {token_response.status_code} - {token_response.text}",
-            401,
+        current_app.logger.error(
+            "Discord Token Error %s - %s",
+            token_response.status_code,
+            token_response.text,
         )
+        flash("Discord Login fehlgeschlagen", "danger")
+        return redirect(url_for("public.login"))
 
     access_token = token_response.json().get("access_token")
 


### PR DESCRIPTION
## Summary
- add random state parameter in Discord OAuth flow
- verify state in callback and log token errors

## Testing
- `python3 -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_684a5d8891c08324a7317606ef2dc3c7