### PR TITLE
Add r3 access requirement to leaderboard route

### DIFF
--- a/web/routes/leaderboard_routes.py
+++ b/web/routes/leaderboard_routes.py
@@ -1,7 +1,11 @@
 from flask import Blueprint, render_template
 
+from web.auth.decorators import r3_required
+
 leaderboard_bp = Blueprint("leaderboard", __name__)
 
+
+@r3_required
 @leaderboard_bp.route("/")
 def leaderboards():
     """Komplette Leaderboard-Übersicht."""


### PR DESCRIPTION
## Summary
- ensure leaderboard overview route requires R3 role

## Testing
- `python3 -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_68469c80bc488324b7a21d2b6f7763a4