### PR TITLE
Inject background logic and report missing cinematic images

### DIFF
--- a/templates/admin/admin.html
+++ b/templates/admin/admin.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/admin.png" %}
 
 {% block title %}Admin Panel{% endblock %}

--- a/templates/admin/calendar.html
+++ b/templates/admin/calendar.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/calendar.png" %}
 
 {% block title %}{{ t("Admin Kalender") }}{% endblock %}

--- a/templates/admin/create_event.html
+++ b/templates/admin/create_event.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/create_event.png" %}
 
 {% block title %}{{ t("Event erstellen") }}{% endblock %}

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/admin.png" %}
 
 {% block title %}{{ t("Admin Dashboard") }}{% endblock %}

--- a/templates/admin/diplomacy.html
+++ b/templates/admin/diplomacy.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/diplomacy.png" %}
 {% block title %}{{ t("Diplomatie") }}{% endblock %}
 

--- a/templates/admin/downloads.html
+++ b/templates/admin/downloads.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/downloads.png" %}
 {% block title %}{{ t("Admin Downloads") }}{% endblock %}
 

--- a/templates/admin/edit_event.html
+++ b/templates/admin/edit_event.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/edit_event.png" %}
 {% block title %}{{ t("Event bearbeiten") }}{% endblock %}
 

--- a/templates/admin/events.html
+++ b/templates/admin/events.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/admin_events.png" %}
 {% block title %}{{ t("Events verwalten") }}{% endblock %}
 

--- a/templates/admin/leaderboards.html
+++ b/templates/admin/leaderboards.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/leaderboard_admin.png" %}
 {% block title %}{{ t("Leaderboards (Admin)") }}{% endblock %}
 

--- a/templates/admin/participants.html
+++ b/templates/admin/participants.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/participants.png" %}
 {% block title %}{{ t("Teilnehmer verwalten") }}{% endblock %}
 

--- a/templates/admin/reminders.html
+++ b/templates/admin/reminders.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/reminders.png" %}
 {% block title %}{{ _('reminder_admin_title') }}{% endblock %}
 

--- a/templates/admin/settings.html
+++ b/templates/admin/settings.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/bot_settings.png" %}
 {% block title %}{{ t("Bot Einstellungen") }}{% endblock %}
 

--- a/templates/admin/tools.html
+++ b/templates/admin/tools.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/tools.png" %}
 {% block title %}{{ t("Wartung & Tools") }}{% endblock %}
 

--- a/templates/admin/translations_editor.html
+++ b/templates/admin/translations_editor.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/translations.png" %}
 {% block title %}{{ t("Übersetzungen bearbeiten") }}{% endblock %}
 

--- a/templates/admin/weekly_report.html
+++ b/templates/admin/weekly_report.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/report.png" %}
 
 {% block title %}{{ t("Wöchentlicher Report") }}{% endblock %}

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/error.png" %}
 
 {% block content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/index.png" %}
 
 {% block title %}{{ _('start_title') }}{% endblock %}

--- a/templates/leaderboard/leaderboards.html
+++ b/templates/leaderboard/leaderboards.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/leaderboard.png" %}
 {% block title %}{{ t("Leaderboards") }}{% endblock %}
 

--- a/templates/members/dashboard.html
+++ b/templates/members/dashboard.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/members.png" %}
 {% block title %}{{ t("Member Dashboard") }}{% endblock %}
 

--- a/templates/members/downloads.html
+++ b/templates/members/downloads.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/downloads_member.png" %}
 {% block title %}{{ t("Downloads") }}{% endblock %}
 

--- a/templates/members/member_dashboard.html
+++ b/templates/members/member_dashboard.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/members_dashboard.png" %}
 {% block title %}{{ t("Member Dashboard") }}{% endblock %}
 

--- a/templates/members/member_downloads.html
+++ b/templates/members/member_downloads.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/downloads_member.png" %}
 {% block title %}{{ t("Downloads") }}{% endblock %}
 

--- a/templates/members/member_stats.html
+++ b/templates/members/member_stats.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/member_stats.png" %}
 {% block title %}{{ t("Mitgliederstatistiken") }}{% endblock %}
 

--- a/templates/members/settings.html
+++ b/templates/members/settings.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/member_settings.png" %}
 {% block title %}{{ t("Einstellungen") }}{% endblock %}
 

--- a/templates/members/stats.html
+++ b/templates/members/stats.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/member_stats.png" %}
 {% block title %}{{ t("Mitgliederstatistiken") }}{% endblock %}
 

--- a/templates/progress.html
+++ b/templates/progress.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/progress.png" %}
 {% block title %}FUR Progress Dashboard{% endblock %}
 {% block content %}

--- a/templates/public/calendar.html
+++ b/templates/public/calendar.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/calendar.png" %}
 
 {% block title %}{{ t("calendar_title") }}{% endblock %}

--- a/templates/public/dashboard.html
+++ b/templates/public/dashboard.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/dashboard.png" %}
 
 {% block title %}{{ t("Dashboard") }}{% endblock %}

--- a/templates/public/error.html
+++ b/templates/public/error.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/error.png" %}
 
 {% block title %}{{ t("Fehler") }}{% endblock %}

--- a/templates/public/events.html
+++ b/templates/public/events.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/events.png" %}
 
 {% block title %}{{ t("Alle geplanten Events") }}{% endblock %}

--- a/templates/public/events_list.html
+++ b/templates/public/events_list.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/events.png" %}
 {% block title %}{{ t("Alle geplanten Events") }}{% endblock %}
 

--- a/templates/public/hall_of_fame.html
+++ b/templates/public/hall_of_fame.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/hof_fire.png" %}
 {% block title %}{{ t("hall_of_fame_title") }}{% endblock %}
 

--- a/templates/public/landing.html
+++ b/templates/public/landing.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/landing.png" %}
 
 {% block title %}{{ t("start_title") }}{% endblock %}

--- a/templates/public/login.html
+++ b/templates/public/login.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/login.png" %}
 
 {% block title %}{{ t("login_title") }}{% endblock %}

--- a/templates/public/lore.html
+++ b/templates/public/lore.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/lore.png" %}
 
 {% block title %}{{ t("lore_title") }}{% endblock %}

--- a/templates/public/public_leaderboard.html
+++ b/templates/public/public_leaderboard.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/leaderboard.png" %}
 {% block title %}{{ t("Leaderboards") }}{% endblock %}
 

--- a/templates/public/view_event.html
+++ b/templates/public/view_event.html
@@ -1,4 +1,5 @@
 {% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/view_event.png" %}
 
 {% block title %}{{ t("event_detail_title") }}{% endblock %}

--- a/todo_missing_bg.md
+++ b/todo_missing_bg.md
@@ -1,0 +1,20 @@
+# ❌ Fehlende Cinematic Backgrounds
+
+Die folgenden Templates enthalten `{% set bg_image = resolve_background_template() %}`, aber es existiert kein passendes Hintergrundbild in `/static/bg/`:
+
+- `diplomacy.html` → fehlt: `static/bg/diplomacy.png`
+- `error.html` → fehlt: `static/bg/error.png`
+- `hall_of_fame.html` → fehlt: `static/bg/hall_of_fame.png`
+- `leaderboards.html` → fehlt: `static/bg/leaderboards.png`
+- `member_dashboard.html` → fehlt: `static/bg/member_dashboard.png`
+- `member_downloads.html` → fehlt: `static/bg/member_downloads.png`
+- `member_stats.html` → fehlt: `static/bg/member_stats.png`
+- `participants.html` → fehlt: `static/bg/participants.png`
+- `progress.html` → fehlt: `static/bg/progress.png`
+- `public_leaderboard.html` → fehlt: `static/bg/public_leaderboard.png`
+- `reminders.html` → fehlt: `static/bg/reminders.png`
+- `settings.html` → fehlt: `static/bg/settings.png`
+- `stats.html` → fehlt: `static/bg/stats.png`
+- `tools.html` → fehlt: `static/bg/tools.png`
+- `translations_editor.html` → fehlt: `static/bg/translations_editor.png`
+- `weekly_report.html` → fehlt: `static/bg/weekly_report.png`


### PR DESCRIPTION
## Summary
- add background template resolver call to all Jinja templates
- generate todo list for missing cinematic background images

## Testing
- `black . && isort . && flake8` *(fails: `flake8` not found)*
- `pytest --disable-warnings --maxfail=1` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684ee557d5dc832491fe4235d54ed2e1