### PR TITLE
🌐 Add i18n for Discord bot cogs

### DIFF
--- a/bot/cogs/base_commands.py
+++ b/bot/cogs/base_commands.py
@@ -7,6 +7,8 @@ Dieses Cog stellt grundlegende Commands bereit, die für alle Servermitglieder n
 import discord
 from discord.ext import commands
 
+from fur_lang.i18n import t
+
 
 class BaseCommands(commands.Cog):
     """
@@ -27,7 +29,7 @@ class BaseCommands(commands.Cog):
         Args:
             ctx (commands.Context): Aufruf-Kontext.
         """
-        await ctx.send("🏓 Pong! FUR is online.")
+        await ctx.send(t("base_ping_pong"))
 
     @commands.command(name="fur")
     async def fur_info(self, ctx: commands.Context) -> None:
@@ -38,7 +40,7 @@ class BaseCommands(commands.Cog):
         Args:
             ctx (commands.Context): Aufruf-Kontext.
         """
-        await ctx.send("🔥 Welcome to the FUR Alliance – Strength, Unity, Respect.")
+        await ctx.send(t("base_fur_info"))
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/bot/cogs/leaderboard.py
+++ b/bot/cogs/leaderboard.py
@@ -5,9 +5,11 @@ Zeigt Top-Spieler in Kategorien wie Raids oder Donations aus der leaderboard-Tab
 """
 
 import logging
+
 from discord.ext import commands
-from web.database import get_db
+
 from fur_lang.i18n import t
+from web.database import get_db
 
 log = logging.getLogger(__name__)
 
@@ -34,19 +36,26 @@ class Leaderboard(commands.Cog):
                 ORDER BY score DESC
                 LIMIT 10
                 """,
-                (category.lower(),)
+                (category.lower(),),
             ).fetchall()
 
             if not rows:
-                await ctx.send(t("leaderboard_unknown_category", category=category, lang=lang))
+                await ctx.send(
+                    t("leaderboard_unknown_category", category=category, lang=lang)
+                )
                 return
 
             header = t("leaderboard_header", category=category.capitalize(), lang=lang)
             content = "\n".join(
-                [f"{i+1}. {row['username']} – {row['score']}" for i, row in enumerate(rows)]
+                [
+                    f"{i+1}. {row['username']} – {row['score']}"
+                    for i, row in enumerate(rows)
+                ]
             )
 
-            await ctx.send(f"{header}\n{content}")
+            await ctx.send(
+                t("leaderboard_message", header=header, content=content, lang=lang)
+            )
             log.info(f"📊 Live-Leaderboard '{category}' gesendet in {ctx.channel.id}")
 
         except Exception as e:

--- a/bot/cogs/newsletter.py
+++ b/bot/cogs/newsletter.py
@@ -5,8 +5,10 @@ Erlaubt es Administratoren, wichtige Nachrichten als Clan-Announcements im Chann
 """
 
 import logging
+
 import discord
 from discord.ext import commands
+
 from fur_lang.i18n import t
 
 log = logging.getLogger(__name__)
@@ -36,8 +38,7 @@ class Newsletter(commands.Cog):
             return
 
         try:
-            announcement = t("announce_prefix", lang=lang) + "\n" + message
-            await ctx.send(announcement)
+            await ctx.send(t("announce_message", message=message, lang=lang))
             log.info(f"📢 Announcement von {ctx.author} in Channel {ctx.channel.id}")
         except discord.Forbidden:
             log.warning("Bot hat keine Berechtigung zum Senden in diesem Channel.")

--- a/translations/de.json
+++ b/translations/de.json
@@ -196,5 +196,21 @@
   "Übersicht": "Übersicht",
   "⏰ Erinnerung auslösen": "⏰ Erinnerung auslösen",
   "🏆 Champion posten": "🏆 Champion posten",
-  "🧪 Healthcheck ausführen": "🧪 Healthcheck ausführen"
+  "🧪 Healthcheck ausführen": "🧪 Healthcheck ausführen",
+  "announce_error": "Fehler beim Senden der Ankündigung.",
+  "announce_message": "📢 {message}",
+  "announce_no_permission": "Bot hat keine Berechtigung zum Senden in diesem Channel.",
+  "announce_usage": "Verwendung: !announce <Nachricht>",
+  "base_fur_info": "🔥 Willkommen bei der FUR-Allianz – Stärke, Einheit, Respekt.",
+  "base_ping_pong": "🏓 Pong! FUR ist online.",
+  "leaderboard_error": "Fehler beim Leaderboard-Versand.",
+  "leaderboard_header": "Top {category}",
+  "leaderboard_message": "{header}\n{content}",
+  "leaderboard_unknown_category": "Kategorie '{category}' ist nicht verfügbar.",
+  "reminder_event_15min": "Erinnerung: Das Event '{title}' startet in 15 Minuten.",
+  "reminder_event_5min": "Erinnerung: Das Event '{title}' startet in 5 Minuten.",
+  "reminder_hourly": "Erinnerung: {time} UTC - prüfe deine Aufgaben!",
+  "reminder_optout_error": "Fehler beim Deaktivieren der Erinnerungen.",
+  "reminder_optout_success": "Du erhältst keine Erinnerungen mehr.",
+  "reminder_optout_usage": "Nutze '!reminder stop', um Erinnerungen zu deaktivieren."
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -196,5 +196,21 @@
   "Übersicht": "Übersicht",
   "⏰ Erinnerung auslösen": "Trigger Reminder",
   "🏆 Champion posten": "Post Champion",
-  "🧪 Healthcheck ausführen": "Run Healthcheck"
+  "🧪 Healthcheck ausführen": "Run Healthcheck",
+  "announce_error": "Error while sending the announcement.",
+  "announce_message": "📢 {message}",
+  "announce_no_permission": "Bot lacks permission to send in this channel.",
+  "announce_usage": "Usage: !announce <message>",
+  "base_fur_info": "🔥 Welcome to the FUR Alliance – Strength, Unity, Respect.",
+  "base_ping_pong": "🏓 Pong! FUR is online.",
+  "leaderboard_error": "Error while sending the leaderboard.",
+  "leaderboard_header": "Top {category}",
+  "leaderboard_message": "{header}\n{content}",
+  "leaderboard_unknown_category": "Category '{category}' is not available.",
+  "reminder_event_15min": "Reminder: The event '{title}' starts in 15 minutes.",
+  "reminder_event_5min": "Reminder: The event '{title}' starts in 5 minutes.",
+  "reminder_hourly": "Reminder: {time} UTC - check your tasks!",
+  "reminder_optout_error": "Error disabling reminders.",
+  "reminder_optout_success": "You will no longer receive reminders.",
+  "reminder_optout_usage": "Use '!reminder stop' to disable reminders."
 }


### PR DESCRIPTION
## Summary
- internationalize all bot messages using `fur_lang.i18n.t`
- add missing translation keys for DE/EN

## Testing
- `isort bot/cogs/base_commands.py bot/cogs/leaderboard.py bot/cogs/newsletter.py translations/en.json translations/de.json`
- `black bot/cogs/base_commands.py bot/cogs/leaderboard.py bot/cogs/newsletter.py`
- `flake8`
- `pytest --maxfail=1 -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684f20eb8f2c83249f488611e44de0b4