### PR TITLE
Update Flask-Babel version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 Flask==3.1.1
-Flask-Babel>=3.1.0
+Flask-Babel==2.0.0
 Flask-Session==0.8.0
 SQLAlchemy==2.0.41
 apscheduler
 deepl
 discord.py==2.5.2
 flask
-flask-babel
+flask-babel==2.0.0
 flask-limiter
 flask-wtf
 ics


### PR DESCRIPTION
## Summary
- pin Flask-Babel to 2.0.0 for compatibility with new `locale_selector_func`

## Testing
- `black web/__init__.py`
- `isort web/__init__.py`
- `flake8`
- `pytest --disable-warnings --maxfail=1` *(fails: SECRET_KEY muss in .env definiert sein!)*

------
https://chatgpt.com/codex/tasks/task_e_684f2aa7b8288324a52a4e54870d00ce