### PR TITLE
Replace flask-babel with flask-babel-next

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+SECRET_KEY=changeme
+DISCORD_TOKEN=your_token
+DISCORD_GUILD_ID=1
+REMINDER_CHANNEL_ID=1
+DISCORD_CLIENT_ID=your_client_id
+DISCORD_CLIENT_SECRET=your_client_secret
+DISCORD_REDIRECT_URI=http://localhost:8080/auth/callback

--- a/codex/tasks/task_migrate_flask_babel_v2.yaml
+++ b/codex/tasks/task_migrate_flask_babel_v2.yaml
@@ -1,14 +1,14 @@
 id: task_migrate_flask_babel_v2
-title: Migriere Projekt auf Flask-Babel ≥2.0 mit locale_selector_func
+title: Migriere Projekt auf Flask-Babel-Next 1.1.0
 description: |
-  Aktualisiere alle Projektdateien auf die neue Syntax von Flask-Babel ≥2.0. Ersetze @babel.localeselector durch babel.locale_selector_func(...) und stelle sicher, dass flask-babel==2.0.0 verwendet wird. Ziel ist zukunftssicherer, CI-tauglicher i18n-Code ohne veraltete Decorator-Syntax.
+  Aktualisiere alle Projektdateien auf die neue Bibliothek flask-babel-next. Ersetze @babel.localeselector durch babel.locale_selector_func(...) und stelle sicher, dass flask-babel-next==1.1.0 verwendet wird. Ziel ist zukunftssicherer, CI-tauglicher i18n-Code ohne veraltete Decorator-Syntax.
   
 steps:
-  - name: Update Abhängigkeit auf flask-babel==2.0.0
+  - name: Update Abhängigkeit auf flask-babel-next==1.1.0
     file: requirements.txt
     action: replace_line
     match: ^flask-babel.*$
-    replacement: flask-babel==2.0.0
+    replacement: flask-babel-next==1.1.0
 
   - name: Entferne alle @babel.localeselector Dekoratoren
     file_glob: "**/*.py"

--- a/codex/tasks/task_migrate_flask_babel_v2.yaml
+++ b/codex/tasks/task_migrate_flask_babel_v2.yaml
@@ -1,32 +1,22 @@
 id: task_migrate_flask_babel_v2
-title: Migriere Projekt auf Flask-Babel-Next 1.1.0
+title: Migriere Projekt auf Flask-Babel 2.0
 description: |
-  Aktualisiere alle Projektdateien auf die neue Bibliothek flask-babel-next. Ersetze @babel.localeselector durch babel.locale_selector_func(...) und stelle sicher, dass flask-babel-next==1.1.0 verwendet wird. Ziel ist zukunftssicherer, CI-tauglicher i18n-Code ohne veraltete Decorator-Syntax.
+  Aktualisiere alle Projektdateien auf die stabile Bibliothek flask-babel==2.0.0.
+  Nutze weiterhin den klassischen Decorator @babel.localeselector.
+  Stelle sicher, dass keine Abhängigkeiten zu flask-babel-next vorhanden sind.
   
 steps:
-  - name: Update Abhängigkeit auf flask-babel-next==1.1.0
+  - name: Update Abhängigkeit auf flask-babel==2.0.0
     file: requirements.txt
     action: replace_line
     match: ^flask-babel.*$
-    replacement: flask-babel-next==1.1.0
+    replacement: flask-babel==2.0.0
 
-  - name: Entferne alle @babel.localeselector Dekoratoren
+  - name: Stelle sicher, dass @babel.localeselector verwendet wird
     file_glob: "**/*.py"
-    action: regex_replace
-    pattern: "@babel\\.localeselector\\s*\\ndef\\s+get_locale\\(.*?\\):.*?(\\n\\s+.*?)*?(?=\\n[^ \\t])"
-    replacement: ""
-
-  - name: Füge neue locale_selector_func ein
-    file: web/__init__.py
-    action: insert_after
-    after: "babel.init_app\\(app\\)"
-    content: |
-      def get_locale():
-          return session.get("lang") or request.accept_languages.best_match(
-              app.config["BABEL_SUPPORTED_LOCALES"]
-          )
-      
-      babel.locale_selector_func(get_locale)
+    action: grep
+    pattern: "@babel.localeselector"
+    error: "❌ Kein @babel.localeselector gefunden"
 
   - name: Verifiziere Imports für session und request
     file: web/__init__.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # 🔧 Core Frameworks
 flask==2.3.3
-flask-babel==2.0.0
+flask-babel-next==1.1.0
 Flask-Session==0.8.0
 flask-wtf
 flask-limiter

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # 🔧 Core Frameworks
 flask==2.3.3
-flask-babel-next==1.1.0
+flask-babel==2.0.0
 Flask-Session==0.8.0
 flask-wtf
 flask-limiter

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,15 @@ import os
 os.environ.setdefault("DISCORD_TOKEN", "dummy")
 os.environ.setdefault("DISCORD_GUILD_ID", "1")
 os.environ.setdefault("REMINDER_CHANNEL_ID", "1")
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("DISCORD_CLIENT_ID", "1")
+os.environ.setdefault("DISCORD_CLIENT_SECRET", "dummy")
+os.environ.setdefault("DISCORD_REDIRECT_URI", "http://localhost:8080/callback")
+os.environ.setdefault("SESSION_LIFETIME_MINUTES", "60")
+os.environ.setdefault("R3_ROLE_IDS", "1")
+os.environ.setdefault("R4_ROLE_IDS", "1")
+os.environ.setdefault("ADMIN_ROLE_IDS", "1")
+os.environ.setdefault("BASE_URL", "http://localhost:8080")
 
 import pytest
 

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -8,7 +8,7 @@ und bindet die zentrale Config-Klasse aus dem Projekt-Root ein.
 import os
 
 from flask import Flask, request, session
-from flask_babel_next import Babel
+from flask_babel import Babel
 
 from config import Config
 from database import close_db
@@ -35,16 +35,14 @@ def create_app():
         "BABEL_TRANSLATION_DIRECTORIES", os.path.join(base_dir, "translations")
     )
 
-    babel = Babel()
-    babel.init_app(app)
+    babel = Babel(app)
 
-    # ✅ Richtiger Aufruf: am Babel-Objekt, nicht Flask
+    # ✅ Klassischer Decorator für Locale-Ermittlung
+    @babel.localeselector
     def get_locale():
         return session.get("lang") or request.accept_languages.best_match(
             app.config["BABEL_SUPPORTED_LOCALES"]
         )
-
-    babel.locale_selector_func(get_locale)  # ✅ korrekt!
 
     # 🌐 Sprache manuell via ?lang=
     @app.before_request

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -6,8 +6,9 @@ und bindet die zentrale Config-Klasse aus dem Projekt-Root ein.
 """
 
 import os
+
 from flask import Flask, request, session
-from flask_babel import Babel
+from flask_babel_next import Babel
 
 from config import Config
 from database import close_db


### PR DESCRIPTION
## Summary
- switch i18n package to `flask-babel-next`
- update Codex migration task
- provide `.env.example` for required variables

## Testing
- `flake8` *(fails: many style errors)*
- `pytest --disable-warnings --maxfail=1` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684f32f193048324b4b8aed5d09cf564