### PR TITLE
Switch to flask-babel-next

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Basic Flask configuration
+SECRET_KEY=change-me
+FLASK_ENV=development
+
+# Internationalization
+BABEL_DEFAULT_LOCALE=de
+BABEL_SUPPORTED_LOCALES=de,en
+
+# Discord settings (required for bot)
+DISCORD_TOKEN=your-token
+DISCORD_GUILD_ID=1234567890
+REMINDER_CHANNEL_ID=1234567890
+DISCORD_CLIENT_ID=your-client-id
+DISCORD_CLIENT_SECRET=your-client-secret
+DISCORD_REDIRECT_URI=http://localhost:8080/callback
+
+# Optional Webhook
+DISCORD_WEBHOOK_URL=

--- a/codex/tasks/task_migrate_flask_babel_v2.yaml
+++ b/codex/tasks/task_migrate_flask_babel_v2.yaml
@@ -1,14 +1,14 @@
 id: task_migrate_flask_babel_v2
 title: Migriere Projekt auf Flask-Babel ≥2.0 mit locale_selector_func
 description: |
-  Aktualisiere alle Projektdateien auf die neue Syntax von Flask-Babel ≥2.0. Ersetze @babel.localeselector durch babel.locale_selector_func(...) und stelle sicher, dass flask-babel==2.0.0 verwendet wird. Ziel ist zukunftssicherer, CI-tauglicher i18n-Code ohne veraltete Decorator-Syntax.
+  Aktualisiere alle Projektdateien auf die neue Syntax von Flask-Babel ≥2.0. Ersetze @babel.localeselector durch babel.locale_selector_func(...) und stelle sicher, dass flask-babel-next verwendet wird. Ziel ist zukunftssicherer, CI-tauglicher i18n-Code ohne veraltete Decorator-Syntax.
   
 steps:
-  - name: Update Abhängigkeit auf flask-babel==2.0.0
+  - name: Update Abhängigkeit auf flask-babel-next
     file: requirements.txt
     action: replace_line
     match: ^flask-babel.*$
-    replacement: flask-babel==2.0.0
+    replacement: flask-babel-next @ git+https://github.com/python-babel/flask-babel.git@next
 
   - name: Entferne alle @babel.localeselector Dekoratoren
     file_glob: "**/*.py"

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,0 +1,20 @@
+# Internationalization (i18n)
+
+This project uses **Flask-Babel-Next** to manage translations. To extract and
+compile messages for new locales you can use the `pybabel` CLI.
+
+```bash
+# Extract messages from the source files
+pybabel extract -F babel.cfg -o messages.pot .
+
+# Initialize a new language, e.g. German
+pybabel init -i messages.pot -d translations -l de
+
+# Update existing locales
+pybabel update -i messages.pot -d translations
+
+# Compile translations for usage in the application
+pybabel compile -d translations
+```
+
+Translations are stored under the `translations/` directory.

--- a/flask_babel_next/__init__.py
+++ b/flask_babel_next/__init__.py
@@ -1,0 +1,1 @@
+from flask_babel import *

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # 🔧 Core Frameworks
 flask==2.3.3
-flask-babel==2.0.0
+flask-babel-next @ git+https://github.com/python-babel/flask-babel.git@next
 Flask-Session==0.8.0
 flask-wtf
 flask-limiter

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -6,11 +6,12 @@ und bindet die zentrale Config-Klasse aus dem Projekt-Root ein.
 """
 
 import os
+
 from flask import Flask, request, session
-from flask_babel import Babel
 
 from config import Config
 from database import close_db
+from flask_babel_next import Babel
 from fur_lang.i18n import current_lang, get_supported_languages, t
 
 try:
@@ -35,15 +36,11 @@ def create_app():
     )
 
     babel = Babel()
-    babel.init_app(app)
-
-    # ✅ Richtiger Aufruf: am Babel-Objekt, nicht Flask
-    def get_locale():
-        return session.get("lang") or request.accept_languages.best_match(
-            app.config["BABEL_SUPPORTED_LOCALES"]
-        )
-
-    babel.locale_selector_func(get_locale)  # ✅ korrekt!
+    babel.init_app(
+        app,
+        locale_selector=lambda: session.get("lang")
+        or request.accept_languages.best_match(app.config["BABEL_SUPPORTED_LOCALES"]),
+    )
 
     # 🌐 Sprache manuell via ?lang=
     @app.before_request


### PR DESCRIPTION
## Summary
- swap flask-babel for flask-babel-next
- set new locale selector syntax in `web/__init__.py`
- add stub package `flask_babel_next`
- add example environment file and docs on i18n usage
- update existing Babel migration task

## Testing
- `flake8 web/__init__.py flask_babel_next/__init__.py` *(fails: F403 'from flask_babel import *' used; E501 line too long)*
- `pytest --disable-warnings --maxfail=1`
- `python main_app.py` *(started Flask app)*

------
https://chatgpt.com/codex/tasks/task_e_684f38d6e70883248937dee9c57a0874