### PR TITLE
Refactor DB connections to env var

### DIFF
--- a/config.py
+++ b/config.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from dotenv import load_dotenv
 
 from fur_lang.i18n import get_supported_languages
-from utils.env_helpers import get_env_bool, get_env_int, get_env_str
+from utils.env_helpers import get_env_int, get_env_str
 
 basedir = os.path.abspath(os.path.dirname(__file__))
 env_path = os.environ.get("ENV_FILE", os.path.join(basedir, ".env"))
@@ -32,13 +32,10 @@ class Config:
     WTF_CSRF_ENABLED: bool = True
 
     # --- Database ---
-    DATABASE_URL: str = get_env_str(
-        "DATABASE_URL",
+    MONGODB_URI: str = get_env_str(
+        "MONGODB_URI",
         required=False,
-        default=os.getenv(
-            "MONGODB_URI",
-            "mongodb+srv://maimarcelgpt:rC3LJVAnnD0Lii0f@furdb.qbrvzgp.mongodb.net/furdb",
-        ),
+        default=os.getenv("MONGODB_URI"),
     )
 
     # --- Discord Integration ---
@@ -50,12 +47,8 @@ class Config:
     DISCORD_CLIENT_SECRET: str = get_env_str("DISCORD_CLIENT_SECRET", required=True)
     DISCORD_REDIRECT_URI: str = get_env_str("DISCORD_REDIRECT_URI", required=True)
 
-    R3_ROLE_IDS: set[str] = set(
-        filter(None, get_env_str("R3_ROLE_IDS", default="").split(","))
-    )
-    R4_ROLE_IDS: set[str] = set(
-        filter(None, get_env_str("R4_ROLE_IDS", default="").split(","))
-    )
+    R3_ROLE_IDS: set[str] = set(filter(None, get_env_str("R3_ROLE_IDS", default="").split(",")))
+    R4_ROLE_IDS: set[str] = set(filter(None, get_env_str("R4_ROLE_IDS", default="").split(",")))
     ADMIN_ROLE_IDS: set[str] = set(
         filter(None, get_env_str("ADMIN_ROLE_IDS", default="").split(","))
     )

--- a/core/memory/init_memory_contexts.py
+++ b/core/memory/init_memory_contexts.py
@@ -1,11 +1,14 @@
 # scripts/init_memory_modules.py
 
-from datetime import datetime
-from pymongo import MongoClient
 import logging
+import os
+from datetime import datetime
+
+from pymongo import MongoClient
 
 # 🔧 MongoDB-Verbindung
-client = MongoClient("mongodb+srv://maimarcelgpt:rC3LJVAnnD0Lii0f@furdb.qbrvzgp.mongodb.net/furdb?retryWrites=true&w=majority&appName=FURdb")
+MONGO_URI = os.getenv("MONGODB_URI")
+client = MongoClient(MONGO_URI)
 db = client["furdb"]
 memory_collection = db["memory_contexts"]
 
@@ -23,7 +26,11 @@ modules = [
         "type": "feature",
         "tags": ["reminder", "discord", "notification", "multilingual"],
         "description": "Reminder-Cog mit Discord-DM, Zeitsteuerung, UI-Adminpanel und Mehrsprachigkeit über fur_lang.",
-        "code_refs": ["discord_bot/cogs/reminder_cog.py", "templates/reminders.html", "core/tasks/reminder_scheduler.py"],
+        "code_refs": [
+            "discord_bot/cogs/reminder_cog.py",
+            "templates/reminders.html",
+            "core/tasks/reminder_scheduler.py",
+        ],
     },
     {
         "_id": "discord_login_roles",
@@ -59,8 +66,9 @@ modules = [
         "tags": ["gpt", "memory", "mongo", "context"],
         "description": "Ermöglicht das Laden aller Memory-Module aus MongoDB als Kontext für GPT oder Systemmodule.",
         "code_refs": ["core/memory/memory_loader.py"],
-    }
+    },
 ]
+
 
 # 🧠 Memory-Kontexte einfügen
 def store_modules():
@@ -72,6 +80,7 @@ def store_modules():
         result = memory_collection.replace_one({"_id": module["_id"]}, module, upsert=True)
         inserted += result.upserted_id is not None or result.modified_count
     return inserted
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)

--- a/database/mongo_client.py
+++ b/database/mongo_client.py
@@ -1,21 +1,13 @@
 # database/mongo_client.py
 
 import os
-from pymongo.mongo_client import MongoClient
-from pymongo.server_api import ServerApi
 
-MONGO_USER = "maimarcelgpt"
-MONGO_PASS = os.getenv("MONGO_PASSWORD", "rC3LJVAnnD0Lii0f")
-MONGO_CLUSTER = "furdb.qbrvzgp"
-MONGO_DB = "furdb"
+from pymongo import MongoClient
 
-uri = (
-    f"mongodb+srv://{MONGO_USER}:{MONGO_PASS}@{MONGO_CLUSTER}.mongodb.net/"
-    f"{MONGO_DB}?retryWrites=true&w=majority&appName=FURdb"
-)
+MONGO_URI = os.getenv("MONGODB_URI")
+client = MongoClient(MONGO_URI)
+db = client["furdb"]  # ← das wird im Projekt importiert
 
-client = MongoClient(uri, server_api=ServerApi('1'))
-db = client[MONGO_DB]  # ← das wird im Projekt importiert
 
 def test_connection():
     try:

--- a/migrate_sqlite_to_mongodb.py
+++ b/migrate_sqlite_to_mongodb.py
@@ -1,8 +1,9 @@
 # migrate_sqlite_to_mongodb.py
 
-import sqlite3
-import pymongo
 import os
+import sqlite3
+
+import pymongo
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -11,7 +12,7 @@ load_dotenv()
 SQLITE_PATH = os.path.abspath("app/data/admin_users.db")  # oder aus init_db_core.py
 
 # 🔗 MongoDB
-MONGO_URI = os.getenv("DATABASE_URL")
+MONGO_URI = os.getenv("MONGODB_URI")
 mongo_client = pymongo.MongoClient(MONGO_URI)
 mongo_db = mongo_client["furdb"]
 

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -6,11 +6,12 @@ und bindet die zentrale Config-Klasse aus dem Projekt-Root ein.
 """
 
 import os
+
 from flask import Flask, request, session
-from flask_babel_next import Babel
 
 from config import Config
 from database import close_db
+from flask_babel_next import Babel
 from fur_lang.i18n import current_lang, get_supported_languages, t
 
 try:
@@ -26,9 +27,11 @@ def create_app():
 
     app = Flask(__name__, template_folder=template_folder, static_folder=static_folder)
     app.config.from_object(Config)
+    app.config["MONGODB_URI"] = os.getenv("MONGODB_URI")
 
     # 🧠 Vorab-Blueprints (z. B. für Memory-Module)
     from web.routes.admin_memory import admin_memory
+
     app.register_blueprint(admin_memory)
 
     # 🌍 Mehrsprachigkeit (Flask-Babel-Next)


### PR DESCRIPTION
## Summary
- use `MONGODB_URI` in central mongo client
- expose URI in Flask app config
- read env var in memory context loader
- update migration script for unified Mongo URI
- cleanup unused import in config

## Testing
- `black` formatting
- `isort` import sorting
- `flake8` *(fails: E501 line too long)*
- `pytest --disable-warnings --maxfail=1` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685357d70b648324b25a966480137e0f