### PR TITLE
Add champion poster generation and webhook test

### DIFF
--- a/champion/autopilot.py
+++ b/champion/autopilot.py
@@ -1,5 +1,7 @@
+"""Automated champion announcement via Discord webhook."""
+
+from champion.webhook import send_discord_webhook
 from utils.champion_data import generate_champion_poster
-from utils.discord_util import send_discord_webhook
 
 
 def run_champion_autopilot():

--- a/champion/webhook.py
+++ b/champion/webhook.py
@@ -1,10 +1,16 @@
-def send_discord_webhook(content, file_path):
-    import requests
+"""Simple helper to send champion posters via Discord webhook."""
 
-    from config import DISCORD_WEBHOOK_URL
+import requests
 
+from config import Config
+
+
+def send_discord_webhook(content: str, file_path: str) -> int:
+    """Upload a file to the configured Discord webhook."""
+
+    webhook_url = Config.DISCORD_WEBHOOK_URL
     with open(file_path, "rb") as f:
         files = {"file": f}
         data = {"content": content}
-        response = requests.post(DISCORD_WEBHOOK_URL, data=data, files=files)
+        response = requests.post(webhook_url, data=data, files=files)
     return response.status_code

--- a/tests/test_champion_poster.py
+++ b/tests/test_champion_poster.py
@@ -1,0 +1,31 @@
+import os
+
+from champion import webhook
+from config import Config
+from utils import champion_data
+
+
+class DummyResponse:
+    def __init__(self, status_code=204):
+        self.status_code = status_code
+
+
+def test_generate_poster_and_webhook(monkeypatch, tmp_path):
+    # redirect output to temp folder
+    monkeypatch.setattr(Config, "STATIC_FOLDER", str(tmp_path))
+    monkeypatch.setattr(Config, "CHAMPION_OUTPUT_REL_PATH", "")
+
+    # dummy request.post
+    def fake_post(url, data=None, files=None):
+        fake_post.called_url = url
+        return DummyResponse()
+
+    monkeypatch.setattr(webhook.requests, "post", fake_post)
+    monkeypatch.setattr(Config, "DISCORD_WEBHOOK_URL", "http://example.com")
+
+    path = champion_data.generate_champion_poster("Tester")
+    assert os.path.isfile(path)
+
+    status = webhook.send_discord_webhook("hello", path)
+    assert status == 204
+    assert fake_post.called_url == "http://example.com"

--- a/utils/champion_data.py
+++ b/utils/champion_data.py
@@ -1,8 +1,13 @@
 """MongoDB-backed champion data helpers."""
 
+import os
+import uuid
 from datetime import datetime
 from typing import Dict, List, Optional
 
+from PIL import Image, ImageDraw, ImageFont
+
+from config import Config
 from mongo_service import get_collection
 
 hof = get_collection("hall_of_fame")
@@ -33,3 +38,27 @@ def add_champion(username: str, honor_title: str, month: str, poster_url: str) -
 
 def get_champion_by_month(month: str) -> Optional[Dict[str, str]]:
     return hof.find_one({"month": month})
+
+
+def generate_champion_poster(username: str = "Champion") -> str:
+    """Generate a simple champion poster image and return file path."""
+
+    output_dir = os.path.join(Config.STATIC_FOLDER, Config.CHAMPION_OUTPUT_REL_PATH)
+    os.makedirs(output_dir, exist_ok=True)
+    file_path = os.path.join(output_dir, f"{uuid.uuid4().hex}.png")
+
+    img = Image.new("RGB", (Config.IMG_WIDTH, Config.IMG_HEIGHT), Config.CHAMPION_BG_COLOR)
+    draw = ImageDraw.Draw(img)
+    try:
+        font = ImageFont.truetype(Config.POSTER_FONT_TITLE_PATH, 64)
+    except OSError:
+        font = ImageFont.load_default()
+
+    bbox = draw.textbbox((0, 0), username, font=font)
+    text_width = bbox[2] - bbox[0]
+    text_height = bbox[3] - bbox[1]
+    x = (Config.IMG_WIDTH - text_width) / 2
+    y = (Config.IMG_HEIGHT - text_height) / 2
+    draw.text((x, y), username, font=font, fill=Config.CHAMPION_TEXT_COLOR)
+    img.save(file_path)
+    return file_path


### PR DESCRIPTION
## Summary
- generate champion poster image in `utils.champion_data`
- fix webhook helper and autopilot to use it
- cover poster generation and webhook call in tests

## Testing
- `flake8 utils/champion_data.py champion/autopilot.py champion/webhook.py tests/test_champion_poster.py`
- `pytest --disable-warnings --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_68546de4ca648324bcf33c380949d873