### PR TITLE
Add i18n support for auth messages

### DIFF
--- a/blueprints/public.py
+++ b/blueprints/public.py
@@ -15,7 +15,7 @@ from flask import (
     url_for,
 )
 
-from fur_lang.i18n import get_supported_languages
+from fur_lang.i18n import get_supported_languages, t
 from mongo_service import db
 from web.auth.decorators import r3_required
 
@@ -50,7 +50,7 @@ def login():
 @public.route("/logout")
 def logout():
     session.clear()
-    flash("Du wurdest erfolgreich ausgeloggt.", "info")
+    flash(t("logout_successful"), "info")
     return redirect(url_for("public.login"))
 
 
@@ -80,9 +80,9 @@ def discord_callback():
     state = request.args.get("state")
 
     if not code:
-        return "Fehlender Code", 400
+        return t("oauth_missing_code"), 400
     if not state or state != session.pop("discord_oauth_state", None):
-        return "Ungültiger OAuth-State", 400
+        return t("oauth_invalid_state"), 400
 
     token_res = requests.post(
         "https://discord.com/api/oauth2/token",
@@ -99,7 +99,7 @@ def discord_callback():
 
     if token_res.status_code != 200:
         current_app.logger.error("OAuth Token Error %s: %s", token_res.status_code, token_res.text)
-        flash("Discord Login fehlgeschlagen", "danger")
+        flash(t("discord_login_failed"), "danger")
         return redirect(url_for("public.login"))
 
     access_token = token_res.json().get("access_token")
@@ -115,7 +115,7 @@ def discord_callback():
         headers={"Authorization": f"Bearer {access_token}"},
     )
     if guild_res.status_code != 200:
-        return "Nicht-Mitglied im FUR Discord-Server", 403
+        return t("discord_not_member"), 403
 
     guild_member = guild_res.json()
     user_roles = set(str(role) for role in guild_member.get("roles", []))
@@ -132,7 +132,7 @@ def discord_callback():
         role_level = "R3"
     else:
         current_app.logger.warning("❌ Keine gültige Discord-Rolle erkannt.")
-        return "Keine gültige Rolle für den Zugriff", 403
+        return t("role_invalid_for_access"), 403
 
     session["user"] = {
         "id": user_data["id"],
@@ -156,7 +156,7 @@ def discord_callback():
         upsert=True,
     )
 
-    flash("Erfolgreich mit Discord eingeloggt", "success")
+    flash(t("discord_login_success"), "success")
 
     if role_level in ["ADMIN", "R4"]:
         return redirect(url_for("admin.dashboard"))
@@ -192,10 +192,10 @@ def view_event(event_id):
 @r3_required
 def join_event(event_id):
     if "user" not in session:
-        flash("Du musst eingeloggt sein.", "warning")
+        flash(t("login_required"), "warning")
         return redirect(url_for("public.login"))
 
-    flash("Du bist dem Event erfolgreich beigetreten!", "success")
+    flash(t("event_join_success"), "success")
     return redirect(url_for("public.view_event", event_id=event_id))
 
 

--- a/translations/ar.json
+++ b/translations/ar.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 الوقت",
   "🗓️ Event Calendar": "🗓 تقويم الحدث",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 الأحداث القادمة"
+  "🧾 Upcoming Events": "🧾 الأحداث القادمة",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/az.json
+++ b/translations/az.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 vaxt",
   "🗓️ Event Calendar": "🗓️ Hadisə təqvimi",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 Qarşıdakı hadisələr"
+  "🧾 Upcoming Events": "🧾 Qarşıdakı hadisələr",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/bg.json
+++ b/translations/bg.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 Време",
   "🗓️ Event Calendar": "🗓 Календар на събитията",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 Предстоящи събития"
+  "🧾 Upcoming Events": "🧾 Предстоящи събития",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/bn.json
+++ b/translations/bn.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 সময়",
   "🗓️ Event Calendar": "🗓 ইভেন্ট ক্যালেন্ডার",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 আসন্ন ঘটনা"
+  "🧾 Upcoming Events": "🧾 আসন্ন ঘটনা",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/ca.json
+++ b/translations/ca.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 Temps",
   "🗓️ Event Calendar": "🗓️ Calendari d'esdeveniments",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 Esdeveniments propers"
+  "🧾 Upcoming Events": "🧾 Esdeveniments propers",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/cs.json
+++ b/translations/cs.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 Čas",
   "🗓️ Event Calendar": "🗓 Kalendář událostí",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 Nadcházející události"
+  "🧾 Upcoming Events": "🧾 Nadcházející události",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/da.json
+++ b/translations/da.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 Tid",
   "🗓️ Event Calendar": "🗓 Begivenhedskalender",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 Kommende begivenheder"
+  "🧾 Upcoming Events": "🧾 Kommende begivenheder",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/de.json
+++ b/translations/de.json
@@ -261,5 +261,16 @@
   "…": "…",
   "⏰ Erinnerung auslösen": "⏰ Erinnerung auslösen",
   "🏆 Champion posten": "🏆 Champion posten",
-  "🧪 Healthcheck ausführen": "🧪 Healthcheck ausführen"
+  "🧪 Healthcheck ausführen": "🧪 Healthcheck ausführen",
+  "member_access_required": "Zugriff nur für Mitglieder möglich.",
+  "admin_access_required": "Nur Admins dürfen diesen Bereich aufrufen.",
+  "superuser_access_required": "Systemzugriff nur für Superuser.",
+  "logout_successful": "Du wurdest erfolgreich ausgeloggt.",
+  "oauth_missing_code": "Fehlender Code",
+  "oauth_invalid_state": "Ungültiger OAuth-State",
+  "discord_login_failed": "Discord Login fehlgeschlagen",
+  "discord_not_member": "Nicht-Mitglied im FUR Discord-Server",
+  "role_invalid_for_access": "Keine gültige Rolle für den Zugriff",
+  "discord_login_success": "Erfolgreich mit Discord eingeloggt",
+  "event_join_success": "Du bist dem Event erfolgreich beigetreten!"
 }

--- a/translations/el.json
+++ b/translations/el.json
@@ -261,5 +261,16 @@
   "…": "…",
   "⏰ Erinnerung auslösen": "⏰ Ενεργοποίηση υπενθύμισης",
   "🏆 Champion posten": "🏆 Δημοσίευση Πρωταθλητή",
-  "🧪 Healthcheck ausführen": "🧪 Εκτέλεση Healthcheck"
+  "🧪 Healthcheck ausführen": "🧪 Εκτέλεση Healthcheck",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -261,5 +261,16 @@
   "…": "…",
   "⏰ Erinnerung auslösen": "Trigger Reminder",
   "🏆 Champion posten": "Post Champion",
-  "🧪 Healthcheck ausführen": "Run Healthcheck"
+  "🧪 Healthcheck ausführen": "Run Healthcheck",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/eo.json
+++ b/translations/eo.json
@@ -261,5 +261,16 @@
   "…": "…",
   "⏰ Erinnerung auslösen": "⏰ Ekigi memorigon",
   "🏆 Champion posten": "🏆 Afiŝi Ĉampionon",
-  "🧪 Healthcheck ausführen": "🧪 Lanĉi Healthcheck"
+  "🧪 Healthcheck ausführen": "🧪 Lanĉi Healthcheck",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/es.json
+++ b/translations/es.json
@@ -261,5 +261,16 @@
   "…": "…",
   "⏰ Erinnerung auslösen": "Activar recordatorio",
   "🏆 Champion posten": "Publicar campeón",
-  "🧪 Healthcheck ausführen": "Ejecutar control de salud"
+  "🧪 Healthcheck ausführen": "Ejecutar control de salud",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/et.json
+++ b/translations/et.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 Aeg",
   "🗓️ Event Calendar": "🗓️ sündmuste kalender",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 Eelseisvad sündmused"
+  "🧾 Upcoming Events": "🧾 Eelseisvad sündmused",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/eu.json
+++ b/translations/eu.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 Ordua",
   "🗓️ Event Calendar": "🗓️ Gertaeren egutegia",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 Hurrengo ekitaldiak"
+  "🧾 Upcoming Events": "🧾 Hurrengo ekitaldiak",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/fa.json
+++ b/translations/fa.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 زمان",
   "🗓️ Event Calendar": "🗓 تقویم رویداد",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 رویدادهای آینده"
+  "🧾 Upcoming Events": "🧾 رویدادهای آینده",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/fi.json
+++ b/translations/fi.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 Aika",
   "🗓️ Event Calendar": "🗓️ Tapahtumakalenteri",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 Tulevat tapahtumat"
+  "🧾 Upcoming Events": "🧾 Tulevat tapahtumat",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -261,5 +261,16 @@
   "…": "…",
   "⏰ Erinnerung auslösen": "Déclencher le rappel",
   "🏆 Champion posten": "Publier le champion",
-  "🧪 Healthcheck ausführen": "Exécuter le contrôle de santé"
+  "🧪 Healthcheck ausführen": "Exécuter le contrôle de santé",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/ga.json
+++ b/translations/ga.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 Am",
   "🗓️ Event Calendar": "🗓️ Féilire na hócáide",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 Imeachtaí atá le teacht"
+  "🧾 Upcoming Events": "🧾 Imeachtaí atá le teacht",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/gl.json
+++ b/translations/gl.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 Tempo",
   "🗓️ Event Calendar": "🗓️ Calendario de eventos",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 Próximos eventos"
+  "🧾 Upcoming Events": "🧾 Próximos eventos",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/he.json
+++ b/translations/he.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 Time",
   "🗓️ Event Calendar": "🗓️ Event Calendar",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 Upcoming Events"
+  "🧾 Upcoming Events": "🧾 Upcoming Events",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/hi.json
+++ b/translations/hi.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 समय",
   "🗓️ Event Calendar": "🗓 इवेंट कैलेंडर",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 आगामी घटनाएं"
+  "🧾 Upcoming Events": "🧾 आगामी घटनाएं",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/hu.json
+++ b/translations/hu.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 idő",
   "🗓️ Event Calendar": "🗓️ Eseménynaptár",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 A közelgő események"
+  "🧾 Upcoming Events": "🧾 A közelgő események",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/id.json
+++ b/translations/id.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 Waktu",
   "🗓️ Event Calendar": "🗓️ Kalender acara",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 Acara mendatang"
+  "🧾 Upcoming Events": "🧾 Acara mendatang",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/it.json
+++ b/translations/it.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 tempo",
   "🗓️ Event Calendar": "🗓️ Calendario degli eventi",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 Eventi imminenti"
+  "🧾 Upcoming Events": "🧾 Eventi imminenti",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒時間",
   "🗓️ Event Calendar": "@イベントカレンダー",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾今後のイベント"
+  "🧾 Upcoming Events": "🧾今後のイベント",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/ko.json
+++ b/translations/ko.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 시간",
   "🗓️ Event Calendar": "🗓️ 이벤트 캘린더",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 다가오는 이벤트"
+  "🧾 Upcoming Events": "🧾 다가오는 이벤트",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/lt.json
+++ b/translations/lt.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 laikas",
   "🗓️ Event Calendar": "🗓️ Įvykių kalendorius",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 Būsimi renginiai"
+  "🧾 Upcoming Events": "🧾 Būsimi renginiai",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/lv.json
+++ b/translations/lv.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 laiks",
   "🗓️ Event Calendar": "🗓️ Pasākumu kalendārs",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 Gaidāmie pasākumi"
+  "🧾 Upcoming Events": "🧾 Gaidāmie pasākumi",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/ms.json
+++ b/translations/ms.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 Masa",
   "🗓️ Event Calendar": "Kalendar Acara 🗓️",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 Acara yang akan datang"
+  "🧾 Upcoming Events": "🧾 Acara yang akan datang",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/nb.json
+++ b/translations/nb.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 Time",
   "🗓️ Event Calendar": "🗓️ Event Calendar",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 Upcoming Events"
+  "🧾 Upcoming Events": "🧾 Upcoming Events",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 Tijd",
   "🗓️ Event Calendar": "🗓️ gebeurteniskalender",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 Aankomende evenementen"
+  "🧾 Upcoming Events": "🧾 Aankomende evenementen",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 Czas",
   "🗓️ Event Calendar": "🗓️ Kalendarz zdarzeń",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 Nadchodzące wydarzenia"
+  "🧾 Upcoming Events": "🧾 Nadchodzące wydarzenia",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 Tempo",
   "🗓️ Event Calendar": "🗓️ Calendário de eventos",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 Os próximos eventos"
+  "🧾 Upcoming Events": "🧾 Os próximos eventos",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/ro.json
+++ b/translations/ro.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 timp",
   "🗓️ Event Calendar": "🗓️ Calendarul evenimentelor",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 Evenimente viitoare"
+  "🧾 Upcoming Events": "🧾 Evenimente viitoare",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 Время",
   "🗓️ Event Calendar": "🗓 Календарь событий",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 Предстоящие события"
+  "🧾 Upcoming Events": "🧾 Предстоящие события",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 Čas",
   "🗓️ Event Calendar": "🗓 Kalendár udalostí",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 Nadchádzajúce udalosti"
+  "🧾 Upcoming Events": "🧾 Nadchádzajúce udalosti",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/sl.json
+++ b/translations/sl.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 Čas",
   "🗓️ Event Calendar": "🗓️ KALENDAR DOGODKE",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 Prihajajoči dogodki"
+  "🧾 Upcoming Events": "🧾 Prihajajoči dogodki",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/sq.json
+++ b/translations/sq.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 Koha",
   "🗓️ Event Calendar": "🗓 Kalendari i ngjarjes",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "Events Ngjarje të ardhshme"
+  "🧾 Upcoming Events": "Events Ngjarje të ardhshme",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/sr.json
+++ b/translations/sr.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 време",
   "🗓️ Event Calendar": "🗓 Календар догађаја",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 Предстојећи догађаји"
+  "🧾 Upcoming Events": "🧾 Предстојећи догађаји",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 tid",
   "🗓️ Event Calendar": "🗓 Evenemangskalendern",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 Kommande evenemang"
+  "🧾 Upcoming Events": "🧾 Kommande evenemang",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/th.json
+++ b/translations/th.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒เวลา",
   "🗓️ Event Calendar": "🗓ปฏิทินกิจกรรม",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾กิจกรรมที่กำลังจะมาถึง"
+  "🧾 Upcoming Events": "🧾กิจกรรมที่กำลังจะมาถึง",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/tr.json
+++ b/translations/tr.json
@@ -261,5 +261,16 @@
   "…": "…",
   "⏰ Erinnerung auslösen": "Hatırlatıcıyı tetikle",
   "🏆 Champion posten": "Şampiyonu yayınla",
-  "🧪 Healthcheck ausführen": "Sağlık Kontrolü Yap"
+  "🧪 Healthcheck ausführen": "Sağlık Kontrolü Yap",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/uk.json
+++ b/translations/uk.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 Час",
   "🗓️ Event Calendar": "🗓 Календар подій",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "🧾 Майбутні події"
+  "🧾 Upcoming Events": "🧾 Майбутні події",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/ur.json
+++ b/translations/ur.json
@@ -394,5 +394,16 @@
   "🕒 Time": "🕒 وقت",
   "🗓️ Event Calendar": "🗓 ایونٹ کیلنڈر",
   "🧪 Healthcheck ausführen": "Run Healthcheck",
-  "🧾 Upcoming Events": "inving آنے والے واقعات"
+  "🧾 Upcoming Events": "inving آنے والے واقعات",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/translations/vi.json
+++ b/translations/vi.json
@@ -261,5 +261,16 @@
   "…": "…",
   "⏰ Erinnerung auslösen": "⏰ Kích hoạt nhắc nhở",
   "🏆 Champion posten": "🏆 Đăng nhà vô địch",
-  "🧪 Healthcheck ausführen": "🧪 Thực hiện kiểm tra sức khỏe"
+  "🧪 Healthcheck ausführen": "🧪 Thực hiện kiểm tra sức khỏe",
+  "member_access_required": "Member-only access required.",
+  "admin_access_required": "Only admins can access this section.",
+  "superuser_access_required": "System access restricted to superusers.",
+  "logout_successful": "You have been logged out successfully.",
+  "oauth_missing_code": "Missing authorization code",
+  "oauth_invalid_state": "Invalid OAuth state",
+  "discord_login_failed": "Discord login failed",
+  "discord_not_member": "Not a member of the FUR Discord server",
+  "role_invalid_for_access": "No valid role for access",
+  "discord_login_success": "Successfully logged in with Discord",
+  "event_join_success": "Successfully joined the event!"
 }

--- a/web/auth/decorators.py
+++ b/web/auth/decorators.py
@@ -9,6 +9,8 @@ from functools import wraps
 
 from flask import flash, redirect, session, url_for
 
+from fur_lang.i18n import t
+
 
 def login_required(view_func):
     """Schützt eine Route für eingeloggte User."""
@@ -16,7 +18,7 @@ def login_required(view_func):
     @wraps(view_func)
     def wrapper(*args, **kwargs):
         if "user" not in session:
-            flash("Du musst eingeloggt sein.", "warning")
+            flash(t("login_required"), "warning")
             return redirect(url_for("public.login"))
         return view_func(*args, **kwargs)
 
@@ -29,7 +31,7 @@ def r3_required(view_func):
     @wraps(view_func)
     def wrapper(*args, **kwargs):
         if session.get("user", {}).get("role_level") not in ["R3", "R4", "ADMIN"]:
-            flash("Zugriff nur für Mitglieder möglich.")
+            flash(t("member_access_required"))
             return redirect(url_for("public.login"))
         return view_func(*args, **kwargs)
 
@@ -42,7 +44,7 @@ def r4_required(view_func):
     @wraps(view_func)
     def wrapper(*args, **kwargs):
         if session.get("user", {}).get("role_level") not in ["R4", "ADMIN"]:
-            flash("Nur Admins dürfen diesen Bereich aufrufen.")
+            flash(t("admin_access_required"))
             return redirect(url_for("public.login"))
         return view_func(*args, **kwargs)
 
@@ -55,7 +57,7 @@ def admin_required(view_func):
     @wraps(view_func)
     def wrapper(*args, **kwargs):
         if session.get("user", {}).get("role_level") != "ADMIN":
-            flash("Systemzugriff nur für Superuser.")
+            flash(t("superuser_access_required"))
             return redirect(url_for("public.login"))
         return view_func(*args, **kwargs)
 


### PR DESCRIPTION
## Summary
- use `t()` translations in auth decorators
- localize public blueprint messages
- add default keys to translation files

## Testing
- `flake8 web/auth/decorators.py blueprints/public.py`
- `pytest --disable-warnings --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_68546de599508324a0daf5e8c8643773