### PR TITLE
Cleanup README merge marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The project follows the FUR Codex standards. Use descriptive commit messages suc
 ## License
 
 This repository is released under the terms of the MIT License. See [LICENSE](LICENSE) for details.
-=======
+
 The **FUR System** is a modular project combining a Flask web app, a Discord bot and a collection of utilities. It is used to manage champion information, reminders and leaderboards for the GGW community.
 
 ## Project layout


### PR DESCRIPTION
## Summary
- remove stray merge marker from README

## Testing
- `black . --check`
- `isort . --check-only` *(fails: imports not sorted)*
- `flake8` *(fails: command not found)*
- `pytest --disable-warnings --maxfail=1` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68548c51159c832499c9b52ac3ec1dc6