### PR TITLE
Add bleach dependency for memory viewer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,7 @@ rich==14.0.0
 setuptools==80.7.1
 types-python-dateutil==2.9.0.20250516
 aiodns>=3.5.0
+bleach>=6.0
 
 # 🧪 Dev & Testing
 pytest>=7.0.0


### PR DESCRIPTION
## Summary
- include `bleach` in `requirements.txt` so the admin memory viewer can sanitize HTML

## Testing
- `pip install -r requirements.txt`
- `black --check .` *(fails: would reformat 88 files)*
- `isort --check .` *(fails with many incorrectly sorted imports)*
- `flake8`
- `pytest --disable-warnings --maxfail=1` *(fails: ValueError about duplicate blueprint)*

------
https://chatgpt.com/codex/tasks/task_e_68548c4d3d64832497c1ee9a0ffcbf72