### PR TITLE
Fix translation JSON syntax

### DIFF
--- a/translations/ar.json
+++ b/translations/ar.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "uuid غير صالح.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "خيار (خيار) غير صالح: لا يمكن إكراه واحد أو أكثر من مدخلات البيانات.",
     "Invalid email address.": "عنوان بريد إلكتروني غير صالح.",
-    "Invalid field name '%s'.": "اسم الحقل غير صالح '٪ s'.",
     "Invalid input.": "مدخل.",
     "Invalid value for {param_hint}: {message}": "قيمة غير صالحة لـ {param_hint}: {message}",
     "Invalid value, can't be any of: %(values)s.": "قيمة غير صالحة ، لا يمكن أن تكون أي من: ٪ (القيم) s.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/az.json
+++ b/translations/az.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "Yanlış UUID.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "Yanlış seçim (lər): Bir və ya daha çox məlumat daxil edilməsi məcbur edilə bilmədi.",
     "Invalid email address.": "Yanlış e-poçt ünvanı.",
-    "Invalid field name '%s'.": "Yanlış sahə adı '% s'.",
     "Invalid input.": "Giriş.",
     "Invalid value for {param_hint}: {message}": "{Param_hint} üçün etibarsız dəyər: {mesaj}",
     "Invalid value, can't be any of: %(values)s.": "Yanlış dəyər, heç biri ola bilməz:% (dəyərlər) s.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/bg.json
+++ b/translations/bg.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "Невалиден uuid.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "Невалиден избор (и): Един или повече входове на данни не могат да бъдат принудени.",
     "Invalid email address.": "Невалиден имейл адрес.",
-    "Invalid field name '%s'.": "Невалидно име на полето '%s'.",
     "Invalid input.": "Вход.",
     "Invalid value for {param_hint}: {message}": "Невалидна стойност за {param_hint}: {съобщение}",
     "Invalid value, can't be any of: %(values)s.": "Невалидна стойност, не може да бъде нито една от: %(стойности) s.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/bn.json
+++ b/translations/bn.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "অবৈধ uuid।",
     "Invalid choice(s): one or more data inputs could not be coerced.": "অবৈধ পছন্দ (গুলি): এক বা একাধিক ডেটা ইনপুট জোর করা যায়নি।",
     "Invalid email address.": "অবৈধ ইমেল ঠিকানা।",
-    "Invalid field name '%s'.": "অবৈধ ক্ষেত্রের নাম '%s'।",
     "Invalid input.": "ইনপুট",
     "Invalid value for {param_hint}: {message}": "{প্যারাম_হিন্ট}: {বার্তা} এর জন্য অবৈধ মান",
     "Invalid value, can't be any of: %(values)s.": "অবৈধ মান, কোনও হতে পারে না: %(মান) গুলি।",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/ca.json
+++ b/translations/ca.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "UUID no vàlid.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "Elecció no vàlida: no es podia coaccionar una o més entrades de dades.",
     "Invalid email address.": "Adreça de correu electrònic no vàlida.",
-    "Invalid field name '%s'.": "Nom del camp no vàlid '%s'.",
     "Invalid input.": "Entrada.",
     "Invalid value for {param_hint}: {message}": "Valor no vàlid per a {param_hint}: {message}",
     "Invalid value, can't be any of: %(values)s.": "Valor no vàlid, no pot ser cap de: %(valors) s.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/cs.json
+++ b/translations/cs.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "Neplatný uuid.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "Neplatný výběr: jeden nebo více vstupů dat nemohl být vynucen.",
     "Invalid email address.": "Neplatná e -mailová adresa.",
-    "Invalid field name '%s'.": "Neplatný název pole '%S'.",
     "Invalid input.": "Vstup.",
     "Invalid value for {param_hint}: {message}": "Neplatná hodnota pro {param_hint}: {message}",
     "Invalid value, can't be any of: %(values)s.": "Neplatná hodnota, nemůže být žádný z: %(hodnoty) s.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/da.json
+++ b/translations/da.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "Ugyldigt uuid.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "Ugyldige valg (er): En eller flere dataindgange kunne ikke tvinges.",
     "Invalid email address.": "Ugyldig e -mail -adresse.",
-    "Invalid field name '%s'.": "Ugyldigt feltnavn '%s'.",
     "Invalid input.": "Input.",
     "Invalid value for {param_hint}: {message}": "Ugyldig værdi for {param_hint}: {besked}",
     "Invalid value, can't be any of: %(values)s.": "Ugyldig værdi, kan ikke være nogen af: %(værdier) s.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/de.json
+++ b/translations/de.json
@@ -272,5 +272,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/el.json
+++ b/translations/el.json
@@ -272,5 +272,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -272,5 +272,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/eo.json
+++ b/translations/eo.json
@@ -272,5 +272,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/es.json
+++ b/translations/es.json
@@ -272,5 +272,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/et.json
+++ b/translations/et.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "Kehtetu UUID.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "Vale valik (d): ühte või mitut andmesisendit ei saanud sundida.",
     "Invalid email address.": "Vale e -posti aadress.",
-    "Invalid field name '%s'.": "Kehtetu välja nimi '%S'.",
     "Invalid input.": "Sisend.",
     "Invalid value for {param_hint}: {message}": "Kehtetu väärtus {param_hint} jaoks: {sõnum}",
     "Invalid value, can't be any of: %(values)s.": "Vale väärtus, ei saa olla ühtegi: %(väärtused) s.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/eu.json
+++ b/translations/eu.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "UUID baliogabea.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "Aukera baliogabea (k): datu sarrera bat edo gehiago ezin izan da hertsatu.",
     "Invalid email address.": "Helbide elektroniko baliogabea.",
-    "Invalid field name '%s'.": "'% S' eremu baliogabea.",
     "Invalid input.": "Sarrera.",
     "Invalid value for {param_hint}: {message}": "Balio baliogabea {param_hint}: {mezua}",
     "Invalid value, can't be any of: %(values)s.": "Balio baliogabea, ezin da hau:% (balioak) s.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/fa.json
+++ b/translations/fa.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "UUID نامعتبر است.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "انتخاب (های) نامعتبر: یک یا چند ورودی داده را نمی توان اجبار کرد.",
     "Invalid email address.": "آدرس ایمیل نامعتبر است.",
-    "Invalid field name '%s'.": 'نام فیلد نامعتبر "٪ s".',
     "Invalid input.": "ورودی",
     "Invalid value for {param_hint}: {message}": "مقدار نامعتبر برای {param_hint}: {پیام}",
     "Invalid value, can't be any of: %(values)s.": "ارزش نامعتبر ، نمی تواند هیچ یک از: ٪ (مقادیر) باشد.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/fi.json
+++ b/translations/fi.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "Virheellinen uuid.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "Virheellinen valinta (t): Yhtä tai useampaa tiedonsiirtoa ei voitu pakottaa.",
     "Invalid email address.": "Virheellinen sähköpostiosoite.",
-    "Invalid field name '%s'.": "Virheellinen kentän nimi '%s'.",
     "Invalid input.": "Tulo.",
     "Invalid value for {param_hint}: {message}": "Virheellinen arvo {param_hint}: {viesti}",
     "Invalid value, can't be any of: %(values)s.": "Virheellinen arvo, ei voi olla mitään: %(arvot) s.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -272,5 +272,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/ga.json
+++ b/translations/ga.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "UUID neamhbhailí.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "Rogha (í) neamhbhailí: Níorbh fhéidir ionchur sonraí amháin nó níos mó a chosc.",
     "Invalid email address.": "Seoladh ríomhphoist neamhbhailí.",
-    "Invalid field name '%s'.": "Ainm an réimse neamhbhailí '%s'.",
     "Invalid input.": "Ionchur.",
     "Invalid value for {param_hint}: {message}": "Luach neamhbhailí do {param_hint}: {teachtaireacht}",
     "Invalid value, can't be any of: %(values)s.": "Luach neamhbhailí, ní féidir a bheith ar aon cheann de: %(luachanna) s.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/gl.json
+++ b/translations/gl.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "UUID non válido.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "Elección (s) non válida: non se puido coaccionar unha ou varias entradas de datos.",
     "Invalid email address.": "Enderezo de correo electrónico non válido.",
-    "Invalid field name '%s'.": 'Nome de campo non válido "%s".',
     "Invalid input.": "Entrada.",
     "Invalid value for {param_hint}: {message}": "Valor non válido para {param_hint}: {mensaxe}",
     "Invalid value, can't be any of: %(values)s.": "Valor non válido, non pode ser ningún dos: %(valores) s.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/he.json
+++ b/translations/he.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "Invalid UUID.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "Invalid choice(s): one or more data inputs could not be coerced.",
     "Invalid email address.": "Invalid email address.",
-    "Invalid field name '%s'.": "Invalid field name '%s'.",
     "Invalid input.": "Invalid input.",
     "Invalid value for {param_hint}: {message}": "Invalid value for {param_hint}: {message}",
     "Invalid value, can't be any of: %(values)s.": "Invalid value, can't be any of: %(values)s.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/hi.json
+++ b/translations/hi.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "अमान्य uuid।",
     "Invalid choice(s): one or more data inputs could not be coerced.": "अमान्य पसंद (ओं): एक या अधिक डेटा इनपुट को मजबूर नहीं किया जा सकता है।",
     "Invalid email address.": "अमान्य ईमेल पता।",
-    "Invalid field name '%s'.": "अमान्य क्षेत्र का नाम '%s'।",
     "Invalid input.": "इनपुट।",
     "Invalid value for {param_hint}: {message}": "{Param_hint} के लिए अमान्य मान: {संदेश}",
     "Invalid value, can't be any of: %(values)s.": "अमान्य मूल्य, कोई भी नहीं हो सकता है: %(मान) एस।",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/hu.json
+++ b/translations/hu.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "Érvénytelen UUID.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "Érvénytelen választás (ek): Egy vagy több adatbevitelt nem lehetett kényszeríteni.",
     "Invalid email address.": "Érvénytelen e -mail cím.",
-    "Invalid field name '%s'.": "Érvénytelen mezőnév '%s'.",
     "Invalid input.": "Bemenet.",
     "Invalid value for {param_hint}: {message}": "Érvénytelen érték a {param_hint}: {üzenet} számára",
     "Invalid value, can't be any of: %(values)s.": "Érvénytelen érték, nem lehet: %(értékek) s.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/id.json
+++ b/translations/id.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "Tidak valid uuid.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "Pilihan tidak valid: satu atau lebih input data tidak dapat dipaksakan.",
     "Invalid email address.": "Alamat email yang tidak valid.",
-    "Invalid field name '%s'.": "Nama lapangan tidak valid '%s'.",
     "Invalid input.": "Masukan.",
     "Invalid value for {param_hint}: {message}": "Nilai tidak valid untuk {param_hint}: {pesan}",
     "Invalid value, can't be any of: %(values)s.": "Nilai tidak valid, tidak bisa salah satu dari: %(nilai) s.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/it.json
+++ b/translations/it.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "UUID non valido.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "Scelte non valide: uno o più input di dati non potevano essere costretti.",
     "Invalid email address.": "Indirizzo e -mail non valido.",
-    "Invalid field name '%s'.": "Nome campo non valido '%s'.",
     "Invalid input.": "Ingresso.",
     "Invalid value for {param_hint}: {message}": "Valore non valido per {param_hint}: {messaggio}",
     "Invalid value, can't be any of: %(values)s.": "Valore non valido, non può essere uno di: %(valori) s.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "無効なuuid。",
     "Invalid choice(s): one or more data inputs could not be coerced.": "無効な選択：1つ以上のデータ入力を強制できませんでした。",
     "Invalid email address.": "無効なメールアドレス。",
-    "Invalid field name '%s'.": "無効なフィールド名「％s」。",
     "Invalid input.": "入力。",
     "Invalid value for {param_hint}: {message}": "{param_hint}の無効な値：{message}",
     "Invalid value, can't be any of: %(values)s.": "無効な値、それはできません：％（値）s。",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/ko.json
+++ b/translations/ko.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "잘못된 uuid.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "유효하지 않은 선택 : 하나 이상의 데이터 입력을 강요 할 수 없습니다.",
     "Invalid email address.": "잘못된 이메일 주소.",
-    "Invalid field name '%s'.": "잘못된 필드 이름 '%s'.",
     "Invalid input.": "입력.",
     "Invalid value for {param_hint}: {message}": "{param_hint}에 대한 잘못된 값 : {message}",
     "Invalid value, can't be any of: %(values)s.": "유효하지 않은 값은 다음 중 어느 것도 될 수 없습니다. %(값) s.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/lt.json
+++ b/translations/lt.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "Neteisingas UUID.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "Neteisingas pasirinkimas (-ai): Vieno ar daugiau duomenų įvesties nepavyko prievarta.",
     "Invalid email address.": "Neteisingas el. Pašto adresas.",
-    "Invalid field name '%s'.": "Neteisingas lauko pavadinimas '%S'.",
     "Invalid input.": "Įvestis.",
     "Invalid value for {param_hint}: {message}": "Neteisinga {param_hint}: {message} reikšmė",
     "Invalid value, can't be any of: %(values)s.": "Neteisinga vertė, negali būti: %(vertės) s.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/lv.json
+++ b/translations/lv.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "Nederīgs UUID.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "Nederīga (-as) izvēle (-as): vienu vai vairākas datu ievades nevarēja piespiest.",
     "Invalid email address.": "Nederīga e -pasta adrese.",
-    "Invalid field name '%s'.": "Nederīgs lauka nosaukums '%s'.",
     "Invalid input.": "Ievade.",
     "Invalid value for {param_hint}: {message}": "Nederīga vērtība {param_hint}: {message}",
     "Invalid value, can't be any of: %(values)s.": "Nederīga vērtība, nevar būt neviena no: %(vērtībām) s.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/ms.json
+++ b/translations/ms.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "Uuid tidak sah.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "Pilihan tidak sah: Satu atau lebih input data tidak boleh dipaksa.",
     "Invalid email address.": "Alamat e -mel tidak sah.",
-    "Invalid field name '%s'.": "Nama medan tidak sah '%s'.",
     "Invalid input.": "Input.",
     "Invalid value for {param_hint}: {message}": "Nilai tidak sah untuk {param_hint}: {mesej}",
     "Invalid value, can't be any of: %(values)s.": "Nilai tidak sah, tidak boleh menjadi: %(nilai) s.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/nb.json
+++ b/translations/nb.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "Invalid UUID.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "Invalid choice(s): one or more data inputs could not be coerced.",
     "Invalid email address.": "Invalid email address.",
-    "Invalid field name '%s'.": "Invalid field name '%s'.",
     "Invalid input.": "Invalid input.",
     "Invalid value for {param_hint}: {message}": "Invalid value for {param_hint}: {message}",
     "Invalid value, can't be any of: %(values)s.": "Invalid value, can't be any of: %(values)s.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "Ongeldige uuid.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "Ongeldige keuze (en): een of meer gegevensinvoer konden niet worden gedwongen.",
     "Invalid email address.": "Ongeldig e -mailadres.",
-    "Invalid field name '%s'.": "Ongeldige veldnaam '%s'.",
     "Invalid input.": "Invoer.",
     "Invalid value for {param_hint}: {message}": "Ongeldige waarde voor {param_hint}: {message}",
     "Invalid value, can't be any of: %(values)s.": "Ongeldige waarde, kan geen van: %(waarden) s zijn.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "Nieprawidłowy UUID.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "Nieprawidłowy wybór: Jeden lub więcej danych wejściowych danych nie można było zmusić.",
     "Invalid email address.": "Nieprawidłowy adres e -mail.",
-    "Invalid field name '%s'.": "Niepoprawna nazwa pola „%s”.",
     "Invalid input.": "Wejście.",
     "Invalid value for {param_hint}: {message}": "Niepoprawna wartość dla {param_hint}: {message}",
     "Invalid value, can't be any of: %(values)s.": "Niepoprawna wartość, nie może być żadna z: %(wartości) s.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "Uuid inválido.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "Escolha inválida (s): uma ou mais entradas de dados não puderam ser coagidas.",
     "Invalid email address.": "Endereço de e -mail inválido.",
-    "Invalid field name '%s'.": "Nome do campo inválido '%s'.",
     "Invalid input.": "Entrada.",
     "Invalid value for {param_hint}: {message}": "Valor inválido para {param_hint}: {message}",
     "Invalid value, can't be any of: %(values)s.": "Valor inválido, não pode ser nenhum dos: %(valores) s.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/ro.json
+++ b/translations/ro.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "UUID nevalid.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "Alegerea nevalide: una sau mai multe intrări de date nu au putut fi constrânse.",
     "Invalid email address.": "Adresa de e -mail nevalide.",
-    "Invalid field name '%s'.": "Numele de câmp nevalid „%s”.",
     "Invalid input.": "Intrare.",
     "Invalid value for {param_hint}: {message}": "Valoare nevalide pentru {param_hint}: {mesaj}",
     "Invalid value, can't be any of: %(values)s.": "Valoare nevalide, nu poate fi niciunul de: %(valori) s.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "Недействительный uuid.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "Неверный выбор (ы): один или несколько входов данных не могут быть принуждены.",
     "Invalid email address.": "Неверный адрес электронной почты.",
-    "Invalid field name '%s'.": "Неверное имя поля '%s'.",
     "Invalid input.": "Вход.",
     "Invalid value for {param_hint}: {message}": "Неверное значение для {param_hint}: {Сообщение}",
     "Invalid value, can't be any of: %(values)s.": "Неверное значение, не может быть любым из: %(значения) s.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "Neplatný uuid.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "Neplatné výbery: Jeden alebo viac vstupov údajov nebolo možné prinútiť.",
     "Invalid email address.": "Neplatná e -mailová adresa.",
-    "Invalid field name '%s'.": "Neplatný názov poľa '%s'.",
     "Invalid input.": "Vstup.",
     "Invalid value for {param_hint}: {message}": "Neplatná hodnota pre {param_hint}: {message}",
     "Invalid value, can't be any of: %(values)s.": "Neplatná hodnota, nemôže byť žiadna z: %(hodnoty) s.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/sl.json
+++ b/translations/sl.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "Neveljaven UUID.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "Neveljavne izbire: enega ali več podatkovnih vhodov ni bilo mogoče prisiliti.",
     "Invalid email address.": "Neveljaven e -poštni naslov.",
-    "Invalid field name '%s'.": "Neveljavno ime polja '%s'.",
     "Invalid input.": "Vnos.",
     "Invalid value for {param_hint}: {message}": "Neveljavna vrednost za {param_hint}: {sporočilo}",
     "Invalid value, can't be any of: %(values)s.": "Neveljavna vrednost, ne more biti nobena od: %(vrednosti) s.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/sq.json
+++ b/translations/sq.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "Uuid i pavlefshëm.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "Zgjedhja (et) e pavlefshme: Një ose më shumë hyrje të të dhënave nuk mund të detyrohen.",
     "Invalid email address.": "Adresa e pavlefshme e postës elektronike.",
-    "Invalid field name '%s'.": "Emri i pavlefshëm i fushës '%s'.",
     "Invalid input.": "Input",
     "Invalid value for {param_hint}: {message}": "Vlera e pavlefshme për {param_hint}: {mesazh}",
     "Invalid value, can't be any of: %(values)s.": "Vlera e pavlefshme, nuk mund të jetë ndonjë nga: %(vlera) s.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/sr.json
+++ b/translations/sr.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "Неважећа ууид.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "Неважећи избор (и): Један или више уноса података се не могу присилити.",
     "Invalid email address.": "Неважећа адреса е-поште.",
-    "Invalid field name '%s'.": "Неважеће име поља '% с'.",
     "Invalid input.": "Улаз.",
     "Invalid value for {param_hint}: {message}": "Неважећа вредност за {парам_хинт}: {мессаге}",
     "Invalid value, can't be any of: %(values)s.": "Неважећа вредност не може бити ниједна од:% (вредности) с.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "Ogiltig UUID.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "Ogiltiga val (er): En eller flera datainmatningar kunde inte tvingas.",
     "Invalid email address.": "Ogiltig e -postadress.",
-    "Invalid field name '%s'.": "Ogiltigt fältnamn '%s'.",
     "Invalid input.": "Input.",
     "Invalid value for {param_hint}: {message}": "Ogiltigt värde för {param_hint}: {meddelande}",
     "Invalid value, can't be any of: %(values)s.": "Ogiltigt värde, kan inte vara någon av: %(värden).",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/th.json
+++ b/translations/th.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "ไม่ถูกต้อง uuid",
     "Invalid choice(s): one or more data inputs could not be coerced.": "ตัวเลือกที่ไม่ถูกต้อง: อินพุตข้อมูลอย่างน้อยหนึ่งรายการไม่สามารถบีบบังคับได้",
     "Invalid email address.": "ที่อยู่อีเมลไม่ถูกต้อง",
-    "Invalid field name '%s'.": "ชื่อฟิลด์ไม่ถูกต้อง '%s'",
     "Invalid input.": "ป้อนข้อมูล.",
     "Invalid value for {param_hint}: {message}": "ค่าไม่ถูกต้องสำหรับ {param_hint}: {message}",
     "Invalid value, can't be any of: %(values)s.": "ค่าที่ไม่ถูกต้องไม่สามารถเป็นของ: %(ค่า) s",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/tr.json
+++ b/translations/tr.json
@@ -272,5 +272,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/uk.json
+++ b/translations/uk.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "Недійсна uuid.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "Недійсний вибір (и): один або кілька входів даних не вдалося примусити.",
     "Invalid email address.": "Недійсна електронна адреса.",
-    "Invalid field name '%s'.": "Недійне ім'я поля '%s'.",
     "Invalid input.": "Введення.",
     "Invalid value for {param_hint}: {message}": "Недійсне значення для {param_hint}: {message}",
     "Invalid value, can't be any of: %(values)s.": "Недійсне значення, не може бути жодним із: %(значення) s.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/ur.json
+++ b/translations/ur.json
@@ -108,7 +108,6 @@
     "Invalid UUID.": "غلط uuid.",
     "Invalid choice(s): one or more data inputs could not be coerced.": "غلط انتخاب (زبانیں): ایک یا زیادہ ڈیٹا ان پٹ پر زبردستی نہیں کی جاسکتی ہے۔",
     "Invalid email address.": "غلط ای میل ایڈریس۔",
-    "Invalid field name '%s'.": "غلط فیلڈ کا نام '٪ s'۔",
     "Invalid input.": "ان پٹ",
     "Invalid value for {param_hint}: {message}": "{param_hint}: {پیغام} کے لئے غلط قیمت",
     "Invalid value, can't be any of: %(values)s.": "غلط قیمت ، کوئی بھی نہیں ہوسکتا: ٪ (اقدار) s.",
@@ -405,5 +404,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }

--- a/translations/vi.json
+++ b/translations/vi.json
@@ -272,5 +272,5 @@
     "Version": "Version",
     "Tags": "Tags",
     "Keine Speicherstände gefunden.": "Keine Speicherstände gefunden.",
-    "Zurück": "Zurück",
+    "Zurück": "Zurück"
 }


### PR DESCRIPTION
## Summary
- repair all JSON files in `translations/`
- drop invalid lines and trailing commas

## Testing
- `black .`
- `isort .`
- `flake8`
- `pytest` *(fails: assert 404 == 302)*

------
https://chatgpt.com/codex/tasks/task_e_68548c4f99148324a4ab4805ca4134d7