### PR TITLE
Add Markdown dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ dependencies = [
   "pymongo>=4.7.0",
   "pydantic>=2.6.4",
   "Flask-Babel>=2.0.0",
-  "python-dotenv>=1.0.1"
+  "python-dotenv>=1.0.1",
+  "Markdown>=3.0"
 ]
 
 [tool.setuptools]

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ python-dateutil
 pytz
 ics
 pillow
+Markdown
 werkzeug
 PyNaCl
 click==8.2.0


### PR DESCRIPTION
## Summary
- install the `Markdown` package to satisfy imports
- list `Markdown` in requirements.txt and pyproject.toml

## Testing
- `pip install -r requirements.txt`
- `pytest --disable-warnings --maxfail=1` *(fails: ModuleNotFoundError: No module named 'mongomock')*

------
https://chatgpt.com/codex/tasks/task_e_6854941a49b0832492d5d9a19ab24d27