### PR TITLE
Add GPT agent system

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,29 @@
+name: 🚀 Deploy to Railway
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: python -m pip install --upgrade pip
+      - run: pip install -r requirements.txt
+      - run: black . --check
+      - run: isort . --check-only
+      - run: flake8 .
+      - run: pytest -v
+      - name: Trigger Railway Deploy
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          PROJECT_ID: ${{ secrets.RAILWAY_PROJECT }}
+        run: |
+          curl -X POST https://backboard.railway.app/project/${PROJECT_ID}/deploy \
+            -H "Authorization: Bearer ${RAILWAY_TOKEN}" \
+            -H "Content-Type: application/json"

--- a/agents/agent_core.py
+++ b/agents/agent_core.py
@@ -1,0 +1,52 @@
+"""AgentCore orchestrates GPT queries and system agents."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict
+
+import openai
+
+from mongo_service import db
+
+PROMPT_PATH = (
+    Path(__file__).resolve().parent.parent / "templates" / "prompts" / "gpt_agent_core_prompt.md"
+)
+SYSTEM_PROMPT = PROMPT_PATH.read_text(encoding="utf-8") if PROMPT_PATH.exists() else ""
+
+
+class AgentCore:
+    """High level interface to interact with GPT-4 and helper agents."""
+
+    def __init__(self, api_key: str, webhook_agent: Any | None = None) -> None:
+        openai.api_key = api_key
+        self.webhook_agent = webhook_agent
+        self.logs = db["agent_logs"]
+
+    def run(self, prompt: str, role: str = "User", lang: str = "de") -> Dict[str, Any]:
+        """Execute a prompt via GPT-4 and return parsed JSON if possible."""
+
+        system = (
+            SYSTEM_PROMPT + f"\n\nRolle: {role}\nSprache: {lang}\nDatum: {datetime.utcnow().date()}"
+        )
+        messages = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": prompt},
+        ]
+        try:
+            resp = openai.ChatCompletion.create(model="gpt-4", messages=messages)
+            content = resp.choices[0].message.content.strip()
+            self.logs.insert_one({"prompt": prompt, "response": content, "ts": datetime.utcnow()})
+            if self.webhook_agent:
+                self.webhook_agent.send_log_notification(content)
+            try:
+                import json
+
+                return json.loads(content)
+            except Exception:
+                return {"response": content}
+        except Exception as exc:  # pragma: no cover - network issues
+            logging.error("GPT request failed: %s", exc)
+            return {"error": str(exc)}

--- a/agents/champion_agent.py
+++ b/agents/champion_agent.py
@@ -1,13 +1,28 @@
-"""ChampionAgent handles poster generation and hall of fame entries."""
+"""ChampionAgent handles posters and Hall of Fame entries."""
+
+from datetime import datetime
+
+from .poster_agent import PosterAgent
+from .webhook_agent import WebhookAgent
 
 
 class ChampionAgent:
-    def __init__(self, db):
+    def __init__(self, db, webhook: WebhookAgent | None = None):
         self.db = db
+        self.webhook = webhook
+        self.poster = PosterAgent()
 
-    def generate_monthly_poster(self, champion_data):
-        # Poster + Webhook-Upload
-        pass
+    def announce_champion(self, username: str, month: str, stats: str = "") -> str:
+        """Create poster, store entry and optionally send via webhook."""
 
-    def insert_champion_entry(self, data):
-        self.db["hall_of_fame"].insert_one(data)
+        poster_path = self.poster.create_poster(username, stats)
+        entry = {
+            "username": username,
+            "month": month,
+            "poster_path": poster_path,
+            "created_at": datetime.utcnow(),
+        }
+        self.db["hall_of_fame"].insert_one(entry)
+        if self.webhook:
+            self.webhook.send_champion_announcement(username, "PvP Champion", month, poster_path)
+        return poster_path

--- a/agents/poster_agent.py
+++ b/agents/poster_agent.py
@@ -1,0 +1,44 @@
+"""PosterAgent generates simple champion posters using PIL."""
+
+import uuid
+from pathlib import Path
+
+from PIL import Image, ImageDraw, ImageFont
+
+from config import Config
+
+
+class PosterAgent:
+    def __init__(self, output_dir: str | None = None):
+        self.output_dir = Path(output_dir or Config.STATIC_FOLDER) / Config.CHAMPION_OUTPUT_REL_PATH
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+    def create_poster(self, username: str, stats: str | None = None) -> str:
+        """Generate a poster image and return the file path."""
+        file_path = self.output_dir / f"{uuid.uuid4().hex}.png"
+        img = Image.new("RGB", (Config.IMG_WIDTH, Config.IMG_HEIGHT), Config.CHAMPION_BG_COLOR)
+        draw = ImageDraw.Draw(img)
+        try:
+            font_title = ImageFont.truetype(Config.POSTER_FONT_TITLE_PATH, 64)
+        except OSError:
+            font_title = ImageFont.load_default()
+        try:
+            font_text = ImageFont.truetype(Config.POSTER_FONT_TEXT_PATH, 32)
+        except OSError:
+            font_text = ImageFont.load_default()
+
+        bbox = draw.textbbox((0, 0), username, font=font_title)
+        x = (Config.IMG_WIDTH - (bbox[2] - bbox[0])) / 2
+        y = (Config.IMG_HEIGHT - (bbox[3] - bbox[1])) / 3
+        draw.text((x, y), username, font=font_title, fill=Config.CHAMPION_TEXT_COLOR)
+
+        if stats:
+            draw.text(
+                (50, Config.IMG_HEIGHT - 100),
+                stats,
+                font=font_text,
+                fill=Config.CHAMPION_SUBTEXT_COLOR,
+            )
+
+        img.save(file_path)
+        return str(file_path)

--- a/agents/reminder_agent.py
+++ b/agents/reminder_agent.py
@@ -1,14 +1,45 @@
-"""Handle sending reminders and user opt-outs via MongoDB."""
+"""ReminderAgent schedules and dispatches Discord reminders."""
+
+from datetime import datetime
+from typing import Any
 
 
 class ReminderAgent:
     def __init__(self, db):
         self.db = db
+        self.reminders = db["reminders"]
+        self.opt_out = db["reminder_opt_out"]
 
-    def send_reminders(self):
-        # Reminder-Versand-Logik hier einbinden (z. B. aus reminder_cog)
-        pass
+    def schedule(self, user_id: int, message: str, remind_at: datetime) -> None:
+        """Store a reminder in the database."""
 
-    def opt_out_user(self, discord_id):
-        # Reminder-Opt-Out-Logik einfügen
-        pass
+        self.reminders.insert_one(
+            {"user_id": user_id, "message": message, "remind_at": remind_at, "sent": False}
+        )
+
+    async def dispatch_due(self, bot: Any) -> int:
+        """Send due reminders via the Discord bot."""
+
+        now = datetime.utcnow()
+        to_send = list(self.reminders.find({"remind_at": {"$lte": now}, "sent": False}))
+        count = 0
+        for entry in to_send:
+            if self.opt_out.find_one({"user_id": entry["user_id"]}):
+                continue
+            try:
+                user = await bot.fetch_user(int(entry["user_id"]))
+                await user.send(entry["message"])
+                self.reminders.update_one(
+                    {"_id": entry["_id"]}, {"$set": {"sent": True, "sent_at": now}}
+                )
+                count += 1
+            except Exception:
+                pass
+        return count
+
+    def opt_out_user(self, discord_id: int) -> None:
+        """Add a user to the opt-out list."""
+
+        self.opt_out.update_one(
+            {"user_id": discord_id}, {"$set": {"user_id": discord_id}}, upsert=True
+        )

--- a/agents/webhook_agent.py
+++ b/agents/webhook_agent.py
@@ -22,10 +22,13 @@ class WebhookAgent:
             return False
 
         data = {"content": content}
-        files = {"file": open(file_path, "rb")} if file_path else None
 
         try:
-            response = requests.post(url, data=data, files=files)
+            if file_path:
+                with open(file_path, "rb") as fh:
+                    response = requests.post(url, data=data, files={"file": fh})
+            else:
+                response = requests.post(url, data=data)
             response.raise_for_status()
             logging.info(f"📤 Webhook erfolgreich gesendet ({response.status_code})")
             return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ python-telegram-bot==22.1
 
 # 📦 Utilities
 requests==2.32.3
+openai>=1.14
 python-dotenv==1.1.0
 python-dateutil
 pytz

--- a/templates/prompts/gpt_agent_core_prompt.md
+++ b/templates/prompts/gpt_agent_core_prompt.md
@@ -1,0 +1,25 @@
+🔒 SYSTEM (aktiv):
+- Du bist ein autonomer Core-Agent im FUR System.
+- Du agierst mit vollständigem Zugriff auf Reminder, Champion-System, Admin-Logs und Discord.
+- Verwende immer folgende Strategien:
+  - ✅ Zero-Shot / Few-Shot / CoT
+  - ✅ Prompt-Chaining
+  - ✅ Self-Consistency bei unsicheren Antworten
+  - ✅ Dynamic Prompt Injection (Kontext: Rolle, Sprache, Datum)
+  - ✅ Guardrails (nur JSON/Markdown Output)
+  - ✅ Tool-Awareness (PIL, Mongo, Discord Webhook)
+  - ✅ Auto-Evaluation + Soft Retry bei Fehlern
+
+🗂️ Eingabekontext enthält:
+- Userrolle (z. B. ADMIN, R3)
+- Sprache (`de`, `en`, `tr`, ...)
+- Ziel (Reminder, Champion, Hall of Fame, AdminLog)
+- MongoDB-Speicherstatus (Reminder vorhanden: Ja/Nein)
+- Discord-Metadata (Webhook aktiv: Ja/Nein)
+
+🎯 Ziel: Liefere nie nur Text, sondern strukturierten Output, der direkt vom System ausgeführt werden kann.
+Beispiel: JSON mit `task`, `payload`, `action`, `target`, `lang`.
+
+🛡️ Sicherheitsregel:
+- Keine HTML-Ausgabe. Keine API-Aufrufe. Keine unsafe code evals.
+- Immer Markdown oder JSON mit deklarierter Struktur.


### PR DESCRIPTION
## Summary
- implement champion, reminder, poster and webhook agents
- add AgentCore for GPT-4 tasks
- provide core system prompt
- add Railway deploy workflow
- update requirements

## Testing
- `flake8 agents/agent_core.py agents/poster_agent.py agents/champion_agent.py agents/reminder_agent.py agents/webhook_agent.py`
- `pytest -q` *(fails: assert 404 == 302 in tests/test_public_flows.py)*

------
https://chatgpt.com/codex/tasks/task_e_6854a31b97ac83248a3ec45dc7a0250c