### PR TITLE
Add champion, reminder and poster blueprints

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,7 +81,7 @@ def app():
     def lore():
         return "lore"
 
-    app.register_blueprint(public)
+    app.register_blueprint(public, name="public_test")
 
     admin_bp = Blueprint("admin", __name__)
 
@@ -89,7 +89,7 @@ def app():
     def dashboard():
         return "admindash"
 
-    app.register_blueprint(admin_bp, url_prefix="/admin")
+    app.register_blueprint(admin_bp, url_prefix="/admin", name="admin_test")
 
     member_bp = Blueprint("member", __name__)
 
@@ -97,7 +97,7 @@ def app():
     def dashboard():
         return "memberdash"
 
-    app.register_blueprint(member_bp, url_prefix="/members")
+    app.register_blueprint(member_bp, url_prefix="/members", name="member_test")
 
     app.config.update({"TESTING": True, "WTF_CSRF_ENABLED": False, "SERVER_NAME": "localhost:8080"})
     with app.app_context():

--- a/web/champion_routes.py
+++ b/web/champion_routes.py
@@ -1,0 +1,32 @@
+"""Routes for champion announcements."""
+
+from datetime import datetime
+
+from flask import Blueprint, jsonify, request
+
+import mongo_service
+from agents.champion_agent import ChampionAgent
+
+champion_blueprint = Blueprint("champion", __name__)
+
+
+@champion_blueprint.get("/champion")
+def get_latest_champion():
+    entry = mongo_service.db["hall_of_fame"].find_one(sort=[("created_at", -1)])
+    if not entry:
+        return jsonify({}), 404
+    entry["_id"] = str(entry["_id"])
+    return jsonify(entry)
+
+
+@champion_blueprint.post("/champion")
+def add_champion():
+    data = request.get_json(force=True) or {}
+    username = data.get("username")
+    month = data.get("month", datetime.utcnow().strftime("%Y-%m"))
+    stats = data.get("stats", "")
+    if not username:
+        return jsonify({"error": "username required"}), 400
+    agent = ChampionAgent(mongo_service.db)
+    poster_path = agent.announce_champion(username, month, stats)
+    return jsonify({"poster_path": poster_path}), 201

--- a/web/poster_routes.py
+++ b/web/poster_routes.py
@@ -1,0 +1,32 @@
+"""Routes for poster handling."""
+
+from pathlib import Path
+
+from flask import Blueprint, jsonify, request, send_from_directory
+
+from agents.poster_agent import PosterAgent
+from config import Config
+
+poster_blueprint = Blueprint("poster", __name__)
+
+
+def _poster_dir() -> Path:
+    path = Path(Config.STATIC_FOLDER) / "posters"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+@poster_blueprint.get("/poster/<path:filename>")
+def get_poster(filename: str):
+    return send_from_directory(_poster_dir(), filename)
+
+
+@poster_blueprint.post("/poster/generate")
+def generate_poster():
+    data = request.get_json(force=True) or {}
+    username = data.get("username", "Champion")
+    stats = data.get("stats")
+    agent = PosterAgent(str(_poster_dir()))
+    path = agent.create_poster(username, stats)
+    filename = Path(path).name
+    return jsonify({"filename": filename})

--- a/web/reminder_routes.py
+++ b/web/reminder_routes.py
@@ -1,0 +1,31 @@
+"""Routes for reminder scheduling."""
+
+from datetime import datetime
+
+from flask import Blueprint, jsonify, request
+
+import mongo_service
+from agents.reminder_agent import ReminderAgent
+
+reminder_blueprint = Blueprint("reminder", __name__)
+
+
+@reminder_blueprint.get("/reminder")
+def list_reminders():
+    reminders = []
+    for r in mongo_service.db["reminders"].find().sort("remind_at", 1):
+        r["_id"] = str(r["_id"])
+        reminders.append(r)
+    return jsonify(reminders)
+
+
+@reminder_blueprint.post("/reminder")
+def create_reminder():
+    data = request.get_json(force=True) or {}
+    try:
+        remind_at = datetime.fromisoformat(data.get("remind_at"))
+    except Exception:
+        return jsonify({"error": "invalid remind_at"}), 400
+    agent = ReminderAgent(mongo_service.db)
+    agent.schedule(int(data.get("user_id", 0)), data.get("message", ""), remind_at)
+    return jsonify({"status": "scheduled"})


### PR DESCRIPTION
## Summary
- implement champion, reminder and poster blueprints
- auto-load web blueprints
- extend tests for new endpoints
- allow registering test blueprints

## Testing
- `flake8 web/champion_routes.py web/reminder_routes.py web/poster_routes.py web/__init__.py tests/test_public_flows.py tests/conftest.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854a84044548324be332c877cee6853