### PR TITLE
Fix landing page background variable

### DIFF
--- a/templates/public/landing.html
+++ b/templates/public/landing.html
@@ -1,5 +1,4 @@
 {% extends "layout.html" %}
-{% set bg_image = resolve_background_template() %}
 {% set bg_image = "/static/bg/landing.png" %}
 
 {% block title %}{{ t("start_title") }}{% endblock %}


### PR DESCRIPTION
## Summary
- clean up redundant background resolver call in `landing.html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b5f2d098832488335f0069895bd2