### PR TITLE
🧠 Fix: Babel integration adjusted for flask_babel_next compatibility

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>{% block title %}{% endblock %}</title>
+  </head>
+  <body>
+    {% block content %}{% endblock %}
+  </body>
+</html>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,15 +21,7 @@ os.environ.setdefault("BASE_URL", "http://localhost:8080")
 import web
 from flask_babel_next import Babel as _BaseBabel
 
-
-class _PatchedBabel(_BaseBabel):
-    def localeselector(self, func):
-        self.locale_selector_func = func
-        return func
-
-
-auto_babel = _PatchedBabel
-web.Babel = auto_babel
+web.Babel = _BaseBabel
 
 import mongomock
 

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -64,7 +64,6 @@ def create_app() -> Flask:
 
     app.register_blueprint(admin_memory, url_prefix="/admin/memory")
 
-    
     # ---------------------------------------------------------------------
     # 🌍 2) Babel-Konfiguration
     # ---------------------------------------------------------------------
@@ -74,22 +73,21 @@ def create_app() -> Flask:
         "BABEL_TRANSLATION_DIRECTORIES",
         str(base_dir / "translations"),
     )
-    
-    babel = Babel()
-    babel.init_app(app)
-    
-    @babel.localeselector
-    def get_locale() -> str:
+
+    def select_locale() -> str:
         return session.get("lang") or request.accept_languages.best_match(
             app.config["BABEL_SUPPORTED_LOCALES"]
         )
-    
+
+    babel = Babel()
+    babel.init_app(app, locale_selector=select_locale)
+
     @app.before_request
     def set_language_from_request() -> None:
         lang = request.args.get("lang")
         if lang in app.config["BABEL_SUPPORTED_LOCALES"]:
             session["lang"] = lang
-    
+
     @app.context_processor
     def inject_globals():
         return {


### PR DESCRIPTION
## Summary
- adjust Babel setup for flask_babel_next
- patch tests for updated Babel
- provide minimal `layout.html` for template inheritance

## Testing
- `flake8 web/__init__.py tests/conftest.py`
- `pytest --disable-warnings --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_6854db410c748324b600f93c95382434