### PR TITLE
Fix admin dashboard visibility

### DIFF
--- a/templates/admin/admin_base.html
+++ b/templates/admin/admin_base.html
@@ -2,7 +2,7 @@
 {% set bg_image = "/static/bg/admin.png" %}
 {% block title %}{{ t("Admin Dashboard") }}{% endblock %}
 
-{% block admin_content %}
+{% block content %}
   <h2 style="font-size: 2.2em;">🛠️ {{ t("Admin Dashboard") }}</h2>
   <p>{{ t("Systemkontrolle, Nutzerverwaltung, Logs, Einstellungen, Tools…") }}</p>
 

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -2,7 +2,7 @@
 {% set bg_image = "/static/bg/admin.png" %}
 {% block title %}{{ t("Admin Dashboard") }}{% endblock %}
 
-{% block admin_content %}
+{% block content %}
   <h2 style="font-size: 2.2em;">🛠️ {{ t("Admin Dashboard") }}</h2>
   <p>{{ t("Systemkontrolle, Nutzerverwaltung, Logs, Einstellungen, Tools…") }}</p>
 

--- a/templates/admin/events.html
+++ b/templates/admin/events.html
@@ -2,7 +2,7 @@
 {% set bg_image = "/static/bg/events_admin.png" %}
 {% block title %}{{ t("Eventverwaltung") }}{% endblock %}
 
-{% block admin_content %}
+{% block content %}
   <h2>📅 {{ t("Eventübersicht") }}</h2>
   <ul>
     {% for e in events %}

--- a/templates/admin/leaderboards.html
+++ b/templates/admin/leaderboards.html
@@ -2,7 +2,7 @@
 {% set bg_image = "/static/bg/leaderboards.png" %}
 {% block title %}{{ t("Leaderboard Verwaltung") }}{% endblock %}
 
-{% block admin_content %}
+{% block content %}
   <h2>🏆 {{ t("Leaderboards") }}</h2>
   <ul>
     {% for lb in leaderboards %}

--- a/templates/admin/participants.html
+++ b/templates/admin/participants.html
@@ -2,7 +2,7 @@
 {% set bg_image = "/static/bg/participants.png" %}
 {% block title %}{{ t("Event-Teilnehmer") }}{% endblock %}
 
-{% block admin_content %}
+{% block content %}
   <h2>👥 {{ t("Teilnehmer für Event") }}: {{ event.title }}</h2>
   <ul>
     {% for user in participants %}

--- a/templates/admin/reminders.html
+++ b/templates/admin/reminders.html
@@ -2,7 +2,7 @@
 {% set bg_image = "/static/bg/reminders.png" %}
 {% block title %}{{ t("reminder_admin_title") }}{% endblock %}
 
-{% block admin_content %}
+{% block content %}
   <h1>🔔 {{ t("reminder_admin_title") }}</h1>
 
   <table class="table">

--- a/templates/admin/settings.html
+++ b/templates/admin/settings.html
@@ -3,7 +3,7 @@
 {% set bg_image = "/static/bg/bot_settings.png" %}
 {% block title %}{{ t("Bot Einstellungen") }}{% endblock %}
 
-{% block admin_content %}
+{% block content %}
   <h2>⚙️ {{ t("Bot-Einstellungen") }}</h2>
 
   <form method="post">

--- a/templates/admin/tools.html
+++ b/templates/admin/tools.html
@@ -2,7 +2,7 @@
 {% set bg_image = "/static/bg/tools.png" %}
 {% block title %}{{ t("Tools & Hilfen") }}{% endblock %}
 
-{% block admin_content %}
+{% block content %}
   <h2>🧰 {{ t("Systemtools") }}</h2>
   <ul>
     <li><a class="btn" href="{{ url_for('admin.refresh_cache') }}">{{ t("Cache leeren") }}</a></li>

--- a/templates/admin/translations_editor.html
+++ b/templates/admin/translations_editor.html
@@ -2,7 +2,7 @@
 {% set bg_image = "/static/bg/lang_editor.png" %}
 {% block title %}{{ t("Übersetzungen bearbeiten") }}{% endblock %}
 
-{% block admin_content %}
+{% block content %}
   <h2>🌐 {{ t("Übersetzungseditor") }}</h2>
 
   <form method="post">

--- a/templates/admin/weekly_report.html
+++ b/templates/admin/weekly_report.html
@@ -2,7 +2,7 @@
 {% set bg_image = "/static/bg/reports.png" %}
 {% block title %}{{ t("weekly_report_title") }}{% endblock %}
 
-{% block admin_content %}
+{% block content %}
   <h2>📄 {{ t("weekly_overview") }}</h2>
 
   {% with messages = get_flashed_messages(with_categories=true) %}


### PR DESCRIPTION
## Summary
- ensure admin templates use the correct content block

## Testing
- `black --check .`
- `isort --check-only .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854e679f3d0832491b6b2bc584db176