### PR TITLE
Fix admin event edit and add Discord post

### DIFF
--- a/templates/admin/edit_event.html
+++ b/templates/admin/edit_event.html
@@ -7,6 +7,7 @@
   <h2>{{ t("Event bearbeiten") }}</h2>
 
   <form method="post">
+    <input type="hidden" name="id" value="{{ event.id if event and event.id is defined else event._id }}">
     <label for="title">{{ t("Titel") }}</label>
     <input type="text" id="title" name="title" value="{{ event.title if event and event.title is defined else '' }}" required>
 

--- a/templates/admin/events.html
+++ b/templates/admin/events.html
@@ -7,8 +7,11 @@
   <ul>
     {% for e in events %}
       <li>
-        {{ e.title }} ({{ e.date }})
+        {{ e.title }} ({{ e.event_date }})
         <a class="btn" href="{{ url_for('admin.edit_event', id=e.id) }}">✏️ {{ t("Bearbeiten") }}</a>
+        <form action="{{ url_for('admin.post_event', event_id=e.id) }}" method="post" style="display:inline;">
+          <button type="submit" class="btn">📢 {{ t('Event posten') }}</button>
+        </form>
       </li>
     {% endfor %}
   </ul>

--- a/translation_keys.json
+++ b/translation_keys.json
@@ -43,6 +43,7 @@
     "Event bearbeiten",
     "Event erstellen",
     "Event erstellen (Admin)",
+    "Event posten",
     "Event-Kalender (Admin)",
     "Events",
     "Events besucht",

--- a/translations/de.json
+++ b/translations/de.json
@@ -47,6 +47,7 @@
     "Event bearbeiten": "Event bearbeiten",
     "Event erstellen": "Event erstellen",
     "Event erstellen (Admin)": "Event erstellen (Admin)",
+    "Event posten": "Event posten",
     "Event-Kalender": "Event-Kalender",
     "Event-Kalender (Admin)": "Event-Kalender (Admin)",
     "Eventdetails": "Eventdetails",

--- a/translations/en.json
+++ b/translations/en.json
@@ -47,6 +47,7 @@
     "Event bearbeiten": "Edit Event",
     "Event erstellen": "Create Event",
     "Event erstellen (Admin)": "Event erstellen (Admin)",
+    "Event posten": "Post Event",
     "Event-Kalender": "Event-Kalender",
     "Event-Kalender (Admin)": "Event-Kalender (Admin)",
     "Eventdetails": "Eventdetails",


### PR DESCRIPTION
## Summary
- allow POST for event editing and save updates
- list events in admin view
- add button to post events via Discord webhook
- expose event id in edit template
- extend translations with "Event posten"

## Testing
- `flake8` *(fails: numerous style violations)*
- `pytest --disable-warnings --maxfail=1`


------
https://chatgpt.com/codex/tasks/task_e_6854eb5abf7483248a927bd027fa7b98