### PR TITLE
Add webhook helper modules with tests

### DIFF
--- a/modules/champion.py
+++ b/modules/champion.py
@@ -1,0 +1,22 @@
+from agents.webhook_agent import WebhookAgent
+from config import Config
+from utils.champion_data import generate_champion_poster
+
+
+def post_champion_poster(username: str = "Champion") -> bool:
+    """Generate a champion poster and post it via ``WebhookAgent``.
+
+    Parameters
+    ----------
+    username:
+        Name that should appear on the poster.
+
+    Returns
+    -------
+    bool
+        ``True`` if posting succeeded, otherwise ``False``.
+    """
+    poster_path = generate_champion_poster(username)
+    webhook = WebhookAgent(Config.DISCORD_WEBHOOK_URL)
+    content = f"\U0001f3c6 {username} wurde Champion!"
+    return webhook.send(content=content, file_path=poster_path)

--- a/modules/weekly_report.py
+++ b/modules/weekly_report.py
@@ -1,0 +1,45 @@
+from datetime import datetime, timedelta
+
+from agents.webhook_agent import WebhookAgent
+from config import Config
+from dashboard.weekly_log_generator import generate_markdown_report
+from mongo_service import get_collection
+
+
+def post_report() -> bool:
+    """Compile the weekly markdown report and post it via ``WebhookAgent``."""
+    now = datetime.utcnow()
+    week_start = now - timedelta(days=7)
+    week_end = now + timedelta(days=7)
+
+    participation = list(
+        get_collection("participants").aggregate(
+            [
+                {
+                    "$lookup": {
+                        "from": "events",
+                        "localField": "event_id",
+                        "foreignField": "_id",
+                        "as": "event",
+                    }
+                },
+                {"$unwind": "$event"},
+                {"$match": {"event.event_time": {"$gte": week_start, "$lte": now}}},
+                {"$group": {"_id": "$user_id", "count": {"$sum": 1}}},
+            ]
+        )
+    )
+
+    upcoming = list(
+        get_collection("events")
+        .find({"event_time": {"$gte": now, "$lte": week_end}}, {"title": 1, "event_time": 1})
+        .sort("event_time", 1)
+    )
+
+    filename = f"{now.date()}-weekly.md"
+    markdown_path = generate_markdown_report(participation, upcoming, filename)
+    with open(markdown_path, "r", encoding="utf-8") as fh:
+        content = f"```\n{fh.read()}\n```"
+
+    webhook = WebhookAgent(Config.DISCORD_WEBHOOK_URL)
+    return webhook.send(content=content)

--- a/tests/test_module_champion.py
+++ b/tests/test_module_champion.py
@@ -1,0 +1,34 @@
+import os
+from pathlib import Path
+
+from config import Config
+from modules import champion as champion_mod
+
+
+class FakeWebhook:
+    def __init__(self, url):
+        self.url = url
+        self.called = False
+        self.kwargs = {}
+
+    def send(self, content: str, webhook_url=None, file_path=None):
+        self.called = True
+        self.kwargs = {"content": content, "file_path": file_path}
+        # ensure file exists
+        assert file_path and Path(file_path).is_file()
+        return True
+
+
+def test_post_champion_poster(monkeypatch, tmp_path):
+    monkeypatch.setattr(Config, "DISCORD_WEBHOOK_URL", "http://example.com")
+
+    def fake_generate(username="Champion"):
+        path = tmp_path / f"{username}.png"
+        path.write_bytes(b"img")
+        return str(path)
+
+    monkeypatch.setattr(champion_mod, "generate_champion_poster", fake_generate)
+    monkeypatch.setattr(champion_mod, "WebhookAgent", FakeWebhook)
+
+    success = champion_mod.post_champion_poster("Tester")
+    assert success

--- a/tests/test_module_weekly_report.py
+++ b/tests/test_module_weekly_report.py
@@ -1,0 +1,50 @@
+from datetime import datetime
+from pathlib import Path
+
+from config import Config
+from modules import weekly_report as report_mod
+
+
+class FakeParticipants:
+    def aggregate(self, pipeline):
+        return [{"_id": "user", "count": 1}]
+
+
+class FakeEvents:
+    def find(self, query, fields):
+        return self
+
+    def sort(self, *args):
+        return [{"title": "Event", "event_time": datetime.utcnow()}]
+
+
+def fake_get_collection(name):
+    if name == "participants":
+        return FakeParticipants()
+    return FakeEvents()
+
+
+class FakeWebhook:
+    def __init__(self, url):
+        self.url = url
+        self.sent = False
+
+    def send(self, content: str, webhook_url=None, file_path=None):
+        self.sent = True
+        assert content.startswith("```")
+        return True
+
+
+def fake_generate(part, upcoming, filename):
+    path = Path(filename)
+    path.write_text("report")
+    return str(path)
+
+
+def test_post_report(monkeypatch):
+    monkeypatch.setattr(Config, "DISCORD_WEBHOOK_URL", "http://example.com")
+    monkeypatch.setattr(report_mod, "generate_markdown_report", fake_generate)
+    monkeypatch.setattr(report_mod, "get_collection", fake_get_collection)
+    monkeypatch.setattr(report_mod, "WebhookAgent", FakeWebhook)
+
+    assert report_mod.post_report() is True


### PR DESCRIPTION
## Summary
- add `modules.champion.post_champion_poster` for poster creation via webhook
- add `modules.weekly_report.post_report` using weekly log generator
- test both helper functions with mocked webhooks

## Testing
- `isort modules tests/test_module_champion.py tests/test_module_weekly_report.py`
- `black modules tests/test_module_champion.py tests/test_module_weekly_report.py`
- `flake8 modules tests/test_module_champion.py tests/test_module_weekly_report.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685543506ba88324897108d09eba1085