### PR TITLE
Update translations editor form

### DIFF
--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -157,7 +157,9 @@ def translations_editor():
     from fur_lang.i18n import get_supported_languages, translations
 
     supported_languages = get_supported_languages()
-    selected_language = request.args.get("lang") or request.form.get("language")
+    selected_language = (
+        request.args.get("language") or request.form.get("language") or request.args.get("lang")
+    )
     if not selected_language and supported_languages:
         selected_language = supported_languages[0]
 
@@ -250,12 +252,18 @@ def post_event(event_id: str):
     else:
         flash("Fehler beim Posten", "danger")
     return redirect(url_for("admin.events"))
+
+
 @admin.route("/post_champion", methods=["POST"])
 @r4_required
 def post_champion():
     from modules.champion import post_champion_poster
+
     success = post_champion_poster()
-    flash("Champion wurde gepostet" if success else "Posten fehlgeschlagen", "success" if success else "danger")
+    flash(
+        "Champion wurde gepostet" if success else "Posten fehlgeschlagen",
+        "success" if success else "danger",
+    )
     return redirect(url_for("admin.admin_dashboard"))
 
 
@@ -263,8 +271,12 @@ def post_champion():
 @r4_required
 def post_weekly_report():
     from modules.weekly_report import post_report
+
     success = post_report()
-    flash("Wochenreport wurde gepostet" if success else "Posten fehlgeschlagen", "success" if success else "danger")
+    flash(
+        "Wochenreport wurde gepostet" if success else "Posten fehlgeschlagen",
+        "success" if success else "danger",
+    )
     return redirect(url_for("admin.admin_dashboard"))
 
 
@@ -281,5 +293,8 @@ def post_announcement():
     content = f"📣 **{title}**\n{message}"
     success = WebhookAgent(Config.DISCORD_WEBHOOK_URL).send(content)
 
-    flash("Ankündigung gesendet" if success else "Senden fehlgeschlagen", "success" if success else "danger")
+    flash(
+        "Ankündigung gesendet" if success else "Senden fehlgeschlagen",
+        "success" if success else "danger",
+    )
     return redirect(url_for("admin.admin_dashboard"))

--- a/templates/admin/translations_editor.html
+++ b/templates/admin/translations_editor.html
@@ -7,9 +7,9 @@
 
   <form method="post">
     <label>{{ t("Sprache") }}:</label>
-    <select name="lang" onchange="this.form.submit()">
-      {% for code in supported_languages %}
-        <option value="{{ code }}" {% if code == selected_lang %}selected{% endif %}>{{ code.upper() }}</option>
+    <select name="language" onchange="this.form.submit()">
+      {% for code in available_languages %}
+        <option value="{{ code }}" {% if code == selected_language %}selected{% endif %}>{{ code.upper() }}</option>
       {% endfor %}
     </select>
   </form>
@@ -18,7 +18,7 @@
     {% for key, value in translations.items() %}
       <div class="form-row">
         <label>{{ key }}</label>
-        <input type="text" name="t_{{ key }}" value="{{ value }}">
+        <input type="text" name="translations[{{ key }}]" value="{{ value }}">
       </div>
     {% endfor %}
     <button class="btn" type="submit">{{ t("Speichern") }}</button>

--- a/tests/test_translations_editor.py
+++ b/tests/test_translations_editor.py
@@ -1,0 +1,28 @@
+import json
+
+from fur_lang import i18n
+from tests.test_memory_viewer import login_admin
+
+
+def test_translations_editor_save(client, app, monkeypatch, tmp_path):
+    login_admin(client)
+    monkeypatch.setattr(app, "root_path", str(tmp_path))
+    translations_dir = tmp_path / "translations"
+    translations_dir.mkdir()
+    i18n.translations.clear()
+    i18n.translations["de"] = {}
+
+    monkeypatch.setattr(i18n, "get_supported_languages", lambda: ["de"])
+
+    resp = client.post("/admin/translations_editor", data={"language": "de"})
+    assert resp.status_code == 200
+
+    resp = client.post(
+        "/admin/translations_editor",
+        data={"language": "de", "translations[greeting]": "Hallo"},
+    )
+    assert resp.status_code == 200
+
+    saved = json.loads((translations_dir / "de.json").read_text())
+    assert saved == {"greeting": "Hallo"}
+    assert i18n.translations["de"] == {"greeting": "Hallo"}


### PR DESCRIPTION
## Summary
- use `selected_language` check and update input names in translations editor
- handle `language` param in admin route
- add test for saving translations

## Testing
- `flake8 blueprints/admin.py tests/test_translations_editor.py`
- `pytest --disable-warnings --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_6855435bf6f48324b0204375feec8dae