### PR TITLE
Enforce R4 access on admin routes

### DIFF
--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -198,21 +198,25 @@ def translations_editor():
 
 
 @admin.route("/trigger_reminder", methods=["POST"])
+@r4_required
 def trigger_reminder():
     return "Reminder triggered"
 
 
 @admin.route("/trigger_champion_post", methods=["POST"])
+@r4_required
 def trigger_champion_post():
     return "Champion post triggered"
 
 
 @admin.route("/healthcheck", methods=["POST"])
+@r4_required
 def healthcheck():
     return Response("ok", status=200)
 
 
 @admin.route("/export_participants")
+@r4_required
 def export_participants():
     csv_data = "username\n"
     return Response(
@@ -223,6 +227,7 @@ def export_participants():
 
 
 @admin.route("/export_scores")
+@r4_required
 def export_scores():
     csv_data = "username,score\n"
     return Response(
@@ -233,6 +238,7 @@ def export_scores():
 
 
 @admin.route("/events/post/<event_id>", methods=["POST"])
+@r4_required
 def post_event(event_id: str):
     """Post an event to Discord via webhook."""
     event = db["events"].find_one({"_id": ObjectId(event_id)})
@@ -250,12 +256,18 @@ def post_event(event_id: str):
     else:
         flash("Fehler beim Posten", "danger")
     return redirect(url_for("admin.events"))
+
+
 @admin.route("/post_champion", methods=["POST"])
 @r4_required
 def post_champion():
     from modules.champion import post_champion_poster
+
     success = post_champion_poster()
-    flash("Champion wurde gepostet" if success else "Posten fehlgeschlagen", "success" if success else "danger")
+    flash(
+        "Champion wurde gepostet" if success else "Posten fehlgeschlagen",
+        "success" if success else "danger",
+    )
     return redirect(url_for("admin.admin_dashboard"))
 
 
@@ -263,8 +275,12 @@ def post_champion():
 @r4_required
 def post_weekly_report():
     from modules.weekly_report import post_report
+
     success = post_report()
-    flash("Wochenreport wurde gepostet" if success else "Posten fehlgeschlagen", "success" if success else "danger")
+    flash(
+        "Wochenreport wurde gepostet" if success else "Posten fehlgeschlagen",
+        "success" if success else "danger",
+    )
     return redirect(url_for("admin.admin_dashboard"))
 
 
@@ -281,5 +297,8 @@ def post_announcement():
     content = f"📣 **{title}**\n{message}"
     success = WebhookAgent(Config.DISCORD_WEBHOOK_URL).send(content)
 
-    flash("Ankündigung gesendet" if success else "Senden fehlgeschlagen", "success" if success else "danger")
+    flash(
+        "Ankündigung gesendet" if success else "Senden fehlgeschlagen",
+        "success" if success else "danger",
+    )
     return redirect(url_for("admin.admin_dashboard"))

--- a/tests/test_admin_auth.py
+++ b/tests/test_admin_auth.py
@@ -1,0 +1,77 @@
+import mongo_service
+
+
+def login_with_role(client, role):
+    with client.session_transaction() as sess:
+        sess["user"] = {"role_level": role}
+
+
+def get_flashes(client):
+    with client.session_transaction() as sess:
+        return sess.get("_flashes", [])
+
+
+def _check_requires_r4(client, method, path):
+    client.get("/logout")
+    resp = client.open(path, method=method)
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/login")
+    flashes = get_flashes(client)
+    assert ("message", "Nur Admins dürfen diesen Bereich aufrufen.") in flashes
+
+    # login as R3
+    login_with_role(client, "R3")
+    resp = client.open(path, method=method)
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/login")
+
+    # login as R4
+    login_with_role(client, "R4")
+    resp = client.open(path, method=method)
+    client.get("/logout")
+    return resp
+
+
+def test_trigger_reminder_requires_r4(client):
+    resp = _check_requires_r4(client, "POST", "/admin/trigger_reminder")
+    assert resp.status_code == 200
+    assert resp.data == b"Reminder triggered"
+
+
+def test_trigger_champion_post_requires_r4(client):
+    resp = _check_requires_r4(client, "POST", "/admin/trigger_champion_post")
+    assert resp.status_code == 200
+    assert resp.data == b"Champion post triggered"
+
+
+def test_healthcheck_requires_r4(client):
+    resp = _check_requires_r4(client, "POST", "/admin/healthcheck")
+    assert resp.status_code == 200
+    assert resp.data == b"ok"
+
+
+def test_export_participants_requires_r4(client):
+    resp = _check_requires_r4(client, "GET", "/admin/export_participants")
+    assert resp.status_code == 200
+    assert resp.mimetype == "text/csv"
+
+
+def test_export_scores_requires_r4(client):
+    resp = _check_requires_r4(client, "GET", "/admin/export_scores")
+    assert resp.status_code == 200
+    assert resp.mimetype == "text/csv"
+
+
+def test_post_event_requires_r4(client):
+    import importlib
+
+    admin_mod = importlib.import_module("blueprints.admin")
+    admin_mod.db = mongo_service.db
+    collection = mongo_service.db["events"]
+    event_id = collection.insert_one(
+        {"title": "T", "description": "d", "event_date": "soon"}
+    ).inserted_id
+    resp = _check_requires_r4(client, "POST", f"/admin/events/post/{event_id}")
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/admin/events")
+    collection.delete_one({"_id": event_id})


### PR DESCRIPTION
## Summary
- require R4/admin role for reminder & export endpoints
- add tests verifying R4 required for admin routes

## Testing
- `flake8 blueprints/admin.py tests/test_admin_auth.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855435796f08324906e61823f955e4f