### PR TITLE
Fix github service token handling

### DIFF
--- a/tests/test_github_service.py
+++ b/tests/test_github_service.py
@@ -1,0 +1,24 @@
+import importlib
+
+
+def _reload_without_token(monkeypatch):
+    monkeypatch.delenv("TOKEN_GITHUB_API", raising=False)
+    monkeypatch.delenv("REPO_GITHUB", raising=False)
+    import utils.github_service as gh_mod
+
+    return importlib.reload(gh_mod)
+
+
+def test_fetch_repo_info_without_token(monkeypatch):
+    gh = _reload_without_token(monkeypatch)
+    assert gh.fetch_repo_info() == {}
+
+
+def test_commit_file_without_token(monkeypatch):
+    gh = _reload_without_token(monkeypatch)
+    assert gh.commit_file("test.txt", "content", "main", "msg") == {}
+
+
+def test_get_branch_sha_without_token(monkeypatch):
+    gh = _reload_without_token(monkeypatch)
+    assert gh.get_branch_sha("main") == ""


### PR DESCRIPTION
## Summary
- warn instead of raising when GitHub token or repo missing
- skip API functions early if token not set
- add regression tests for GitHub service without token

## Testing
- `flake8 utils/github_service.py tests/test_github_service.py`
- `pytest --disable-warnings --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_6855e2b35ba08324af089a95087bb7b1