### PR TITLE
Improve Champion autopilot

### DIFF
--- a/agents/scheduler_agent.py
+++ b/agents/scheduler_agent.py
@@ -3,8 +3,12 @@ SchedulerAgent – verwaltet geplante Aufgaben, CRON-artige Abläufe, Reminder
 """
 
 import logging
-import schedule
 import time
+
+import schedule
+
+from champion.autopilot import run_champion_autopilot
+
 
 class SchedulerAgent:
     def __init__(self):
@@ -19,3 +23,14 @@ class SchedulerAgent:
         while True:
             schedule.run_pending()
             time.sleep(1)
+
+    def schedule_champion_autopilot(
+        self, interval_hours: int = 24, month: str | None = None, username: str | None = None
+    ) -> None:
+        """Schedule the champion autopilot to run regularly."""
+
+        job = schedule.every(interval_hours).hours.do(
+            run_champion_autopilot, month=month, username=username
+        )
+        self.jobs.append(job)
+        logging.info("\U0001f4c5 Champion Autopilot every %s hours scheduled", interval_hours)

--- a/champion/autopilot.py
+++ b/champion/autopilot.py
@@ -1,9 +1,40 @@
 """Automated champion announcement via Discord webhook."""
 
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
 from champion.webhook import send_discord_webhook
 from utils.champion_data import generate_champion_poster
 
 
-def run_champion_autopilot():
-    poster_path = generate_champion_poster()
-    send_discord_webhook(content="🏆 New Champion crowned!", file_path=poster_path)
+def run_champion_autopilot(month: Optional[str] = None, username: Optional[str] = None) -> bool:
+    """Post a champion announcement poster via the Discord webhook.
+
+    Parameters
+    ----------
+    month:
+        Optional month label to announce, e.g. ``"June"``.
+    username:
+        Name that should appear on the poster.
+
+    Returns
+    -------
+    bool
+        ``True`` if sending succeeded, otherwise ``False``.
+    """
+
+    username = username or "Champion"
+    try:
+        poster_path = generate_champion_poster(username)
+        if month:
+            content = f"\U0001f3c6 Champion for {month} crowned!"
+        else:
+            content = "\U0001f3c6 New Champion crowned!"
+        send_discord_webhook(content=content, file_path=poster_path)
+        logging.info("Champion autopilot executed for %s in %s", username, month)
+        return True
+    except Exception:  # noqa: BLE001
+        logging.exception("Champion autopilot failed")
+        return False


### PR DESCRIPTION
## Summary
- enhance champion autopilot with error handling, logging and custom parameters
- add schedule method for champion autopilot
- expand tests for autopilot functionality

## Testing
- `flake8 champion/autopilot.py agents/scheduler_agent.py tests/test_module_champion.py`
- `pytest --disable-warnings --maxfail=1`


------
https://chatgpt.com/codex/tasks/task_e_6855e2b028ec8324bf2404e2c6f8022f