### PR TITLE
Implement translation sync + tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 
 ## Unreleased
 - Memory Viewer added
+- TranslationAgent now syncs and auto-translates missing keys

--- a/agents/translation_agent.py
+++ b/agents/translation_agent.py
@@ -1,14 +1,77 @@
 """
 TranslationAgent – automatisiert Übersetzungen und JSON-Synchronisation
 """
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict
+
+
 class TranslationAgent:
-    def __init__(self, lang_dir="translations"):
-        self.lang_dir = lang_dir
+    def __init__(self, lang_dir: str | Path = "translations"):
+        self.lang_dir = Path(lang_dir)
 
-    def sync(self):
-        # i18n-Synchronisation hier einfügen
-        pass
+    def _load_translations(self) -> Dict[str, Dict[str, str]]:
+        data: Dict[str, Dict[str, str]] = {}
+        for path in self.lang_dir.glob("*.json"):
+            try:
+                with path.open(encoding="utf-8") as f:
+                    data[path.stem] = json.load(f)
+            except json.JSONDecodeError:
+                data[path.stem] = {}
+        return data
 
-    def auto_translate_missing(self):
-        # Automatische Übersetzungen starten
-        pass
+    def sync(self) -> None:
+        """Synchronise all translation files with a unified key set."""
+
+        data = self._load_translations()
+        all_keys = set().union(*data.values()) if data else set()
+
+        keys_file = Path("translation_keys.json")
+        if keys_file.exists():
+            try:
+                with keys_file.open(encoding="utf-8") as f:
+                    all_keys.update(json.load(f))
+            except json.JSONDecodeError:
+                # try to recover from trailing comma
+                raw = keys_file.read_text(encoding="utf-8")
+                raw = raw.rstrip().rstrip(",")
+                try:
+                    all_keys.update(json.loads(raw + "]"))
+                except Exception:
+                    pass
+
+        for lang, entries in data.items():
+            missing = [k for k in all_keys if k not in entries]
+            if not missing:
+                continue
+            for key in missing:
+                entries[key] = ""
+            with (self.lang_dir / f"{lang}.json").open("w", encoding="utf-8") as f:
+                json.dump(entries, f, indent=2, ensure_ascii=False)
+
+    def auto_translate_missing(self) -> None:
+        """Fill missing translations using the auto_fill helper."""
+
+        from i18n_tools import auto_fill
+
+        self.sync()
+        original_dir = auto_fill.TRANSLATIONS_DIR
+        auto_fill.TRANSLATIONS_DIR = self.lang_dir
+        try:
+            data = auto_fill.load_all()
+            base = data.get(auto_fill.BASE_LANG, {})
+            all_keys = set().union(*data.values()) if data else set()
+
+            for lang, entries in data.items():
+                missing = [k for k in all_keys if not entries.get(k)]
+                if not missing:
+                    continue
+                for key in missing:
+                    source = base.get(key, key)
+                    entries[key] = auto_fill.translate(source, lang)
+                auto_fill.save_lang(lang, entries)
+        finally:
+            auto_fill.TRANSLATIONS_DIR = original_dir

--- a/tests/test_translation_agent.py
+++ b/tests/test_translation_agent.py
@@ -1,0 +1,37 @@
+import json
+
+from agents.translation_agent import TranslationAgent
+
+
+def test_sync_adds_missing_keys(tmp_path):
+    lang_dir = tmp_path / "translations"
+    lang_dir.mkdir()
+    (lang_dir / "en.json").write_text(json.dumps({"hello": "Hello"}))
+    (lang_dir / "de.json").write_text(json.dumps({}))
+
+    agent = TranslationAgent(lang_dir=lang_dir)
+    agent.sync()
+
+    data = json.loads((lang_dir / "de.json").read_text())
+    assert data.get("hello") == ""
+
+
+def test_auto_translate_missing(monkeypatch, tmp_path):
+    lang_dir = tmp_path / "translations"
+    lang_dir.mkdir()
+    (lang_dir / "en.json").write_text(json.dumps({"hello": "Hello"}))
+    (lang_dir / "de.json").write_text(json.dumps({"hello": ""}))
+
+    from i18n_tools import auto_fill
+
+    def fake_translate(text: str, target: str) -> str:
+        return f"{target}:{text}"
+
+    monkeypatch.setattr(auto_fill, "TRANSLATIONS_DIR", lang_dir)
+    monkeypatch.setattr(auto_fill, "translate", fake_translate)
+
+    agent = TranslationAgent(lang_dir=lang_dir)
+    agent.auto_translate_missing()
+
+    data = json.loads((lang_dir / "de.json").read_text())
+    assert data["hello"] == "de:Hello"


### PR DESCRIPTION
## Summary
- implement real logic for TranslationAgent sync and auto translation
- add unit tests for the new behavior
- document the feature in CHANGELOG

## Testing
- `pytest tests/test_translation_agent.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855e2b15bfc8324b23386078ab8b411