### PR TITLE
Add example env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+ENV_FILE=.env                            # Optional path to your env file
+SECRET_KEY=changeme                     # Flask session secret
+FLASK_ENV=development                   # Application environment
+SESSION_LIFETIME_MINUTES=60             # Session expiry in minutes
+MONGODB_URI=mongodb://localhost:27017/furdb  # MongoDB connection
+DISCORD_WEBHOOK_URL=                    # Optional Discord webhook
+DISCORD_TOKEN=your-discord-bot-token    # Discord bot token
+DISCORD_GUILD_ID=1234567890             # Discord server ID
+REMINDER_CHANNEL_ID=1234567890          # Channel ID for reminders
+DISCORD_CLIENT_ID=your-client-id        # OAuth client ID
+DISCORD_CLIENT_SECRET=your-client-secret  # OAuth client secret
+DISCORD_REDIRECT_URI=https://example.com/discord/callback  # OAuth redirect URL
+R3_ROLE_IDS=111,222                     # Comma-separated R3 role IDs
+R4_ROLE_IDS=333,444                     # Comma-separated R4 role IDs
+ADMIN_ROLE_IDS=555,666                  # Comma-separated admin role IDs
+BASE_URL=http://localhost:8080          # Public base URL

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ flag/* merge=ours
 # Umgebungsvariablen / Sicherheit
 .env
 .env.*
+!.env.example
 secrets.json
 *.sqlite3
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ The FUR System powers the champion, reminder and leaderboard features for the GG
 
 ## Setup
 
+Copy `.env.example` to `.env` and adjust the values for your environment before running the setup commands.
+
 ```bash
 pip install -r requirements.txt
 black . && isort . && flake8


### PR DESCRIPTION
## Summary
- provide `.env.example` with all config variables
- document env setup in README
- allow `.env.example` via `.gitignore`

## Testing
- `black .`
- `isort .`
- `flake8`
- `pytest --disable-warnings --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_685683312e3c8324bc03b0198c28e8f3