### PR TITLE
Improve champion autopilot logging

### DIFF
--- a/champion/autopilot.py
+++ b/champion/autopilot.py
@@ -32,7 +32,13 @@ def run_champion_autopilot(month: Optional[str] = None, username: Optional[str] 
             content = f"\U0001f3c6 Champion for {month} crowned!"
         else:
             content = "\U0001f3c6 New Champion crowned!"
-        send_discord_webhook(content=content, file_path=poster_path)
+        status = send_discord_webhook(content=content, file_path=poster_path)
+        if status // 100 != 2:
+            logging.warning(
+                "Champion autopilot webhook returned status %s for %s", status, username
+            )
+            return False
+
         logging.info("Champion autopilot executed for %s in %s", username, month)
         return True
     except Exception:  # noqa: BLE001

--- a/tests/test_module_champion.py
+++ b/tests/test_module_champion.py
@@ -70,3 +70,20 @@ def test_run_champion_autopilot_error(monkeypatch, tmp_path):
     monkeypatch.setattr(autopilot_mod, "send_discord_webhook", fake_send)
 
     assert autopilot_mod.run_champion_autopilot() is False
+
+
+def test_run_champion_autopilot_bad_status(monkeypatch, tmp_path):
+    from champion import autopilot as autopilot_mod
+
+    def fake_generate(username="Champion"):
+        path = tmp_path / f"{username}.png"
+        path.write_bytes(b"img")
+        return str(path)
+
+    def fake_send(*args, **kwargs):
+        return 500
+
+    monkeypatch.setattr(autopilot_mod, "generate_champion_poster", fake_generate)
+    monkeypatch.setattr(autopilot_mod, "send_discord_webhook", fake_send)
+
+    assert autopilot_mod.run_champion_autopilot() is False


### PR DESCRIPTION
## Summary
- capture status code from Discord webhook
- warn and return False when status isn't 2xx
- test non-2xx webhook response

## Testing
- `flake8`
- `pytest --disable-warnings --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_685683318af883248c608d292f16de64