### PR TITLE
Add Makefile and developer checklist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.DEFAULT_GOAL := check
+.PHONY: lint test check
+
+lint:
+	black .
+	isort .
+	flake8 .
+
+test:
+	pytest --disable-warnings
+
+check: lint test

--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ black . && isort . && flake8
 pytest --disable-warnings --maxfail=1
 ```
 
+## Developer Checklist
+
+Use the `Makefile` to run common tasks:
+```bash
+make        # run lint and tests
+make lint   # formatting and flake8
+make test   # run pytest
+```
+
 ## Continuous Integration
 
 Every pull request triggers the automated release flow:


### PR DESCRIPTION
## Summary
- provide a Makefile with lint, test and check targets
- document the new Makefile in README under a Developer Checklist

## Testing
- `black . --check`
- `isort --check-only .`
- `flake8 .`
- `pytest --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68569df0a31c83248364cc3350ff32f5