### PR TITLE
Fix Mongo defaults

### DIFF
--- a/fur_mongo.py
+++ b/fur_mongo.py
@@ -4,12 +4,14 @@ Verbindet sich mit der Datenbank 'furdb' und stellt globale Collection-Zugriffe 
 """
 
 import logging
-import os
+import warnings
 
 from dotenv import load_dotenv
 from pymongo import MongoClient
 from pymongo.errors import ConnectionFailure
 from pymongo.server_api import ServerApi
+
+from utils.env_helpers import get_env_str
 
 # === Nur bei Direktstart .env laden ===
 if __name__ == "__main__":
@@ -20,10 +22,14 @@ logger = logging.getLogger("fur_mongo")
 logging.basicConfig(level=logging.INFO)
 
 # === MongoDB-URI aus Umgebungsvariable ===
-MONGO_URI = os.getenv("MONGODB_URI") or "❌MONGODB_URI_NOT_SET"
-
-if "❌" in MONGO_URI:
-    raise EnvironmentError("Fehlende Umgebungsvariable MONGODB_URI")
+MONGO_URI = get_env_str("MONGODB_URI", required=False)
+if not MONGO_URI:
+    warnings.warn(
+        "MONGODB_URI not set, falling back to local MongoDB URI",
+        RuntimeWarning,
+    )
+    logger.warning("MONGODB_URI not set, using default localhost URI")
+    MONGO_URI = "mongodb://localhost:27017/furdb"
 
 # === Verbindung herstellen ===
 try:

--- a/mongo_service.py
+++ b/mongo_service.py
@@ -1,14 +1,21 @@
 import logging
-import os
+import warnings
 
 from pymongo import MongoClient
 from pymongo.errors import ConnectionFailure
 
+from utils.env_helpers import get_env_str
+
 logger = logging.getLogger(__name__)
 
-MONGO_URI = os.getenv("MONGODB_URI")
+MONGO_URI = get_env_str("MONGODB_URI", required=False)
 if not MONGO_URI:
-    raise RuntimeError("MONGODB_URI not set")
+    warnings.warn(
+        "MONGODB_URI not set, falling back to local MongoDB URI",
+        RuntimeWarning,
+    )
+    logger.warning("MONGODB_URI not set, using default localhost URI")
+    MONGO_URI = "mongodb://localhost:27017/furdb"
 
 client = MongoClient(MONGO_URI)
 logger.info("MongoDB connected: %s", bool(client))

--- a/tests/test_mongo_defaults.py
+++ b/tests/test_mongo_defaults.py
@@ -1,0 +1,30 @@
+import importlib
+
+import mongomock
+
+import fur_mongo
+import mongo_service
+
+
+def _reload_mongo_service(monkeypatch):
+    monkeypatch.delenv("MONGODB_URI", raising=False)
+    mod = importlib.reload(mongo_service)
+    mod.client = mongomock.MongoClient()
+    mod.db = mod.client["testdb"]
+    return mod
+
+
+def _reload_fur_mongo(monkeypatch):
+    monkeypatch.delenv("MONGODB_URI", raising=False)
+    monkeypatch.setattr("pymongo.MongoClient", mongomock.MongoClient)
+    return importlib.reload(fur_mongo)
+
+
+def test_mongo_service_import_without_uri(monkeypatch):
+    mod = _reload_mongo_service(monkeypatch)
+    assert mod.MONGO_URI == "mongodb://localhost:27017/furdb"
+
+
+def test_fur_mongo_import_without_uri(monkeypatch):
+    mod = _reload_fur_mongo(monkeypatch)
+    assert mod.MONGO_URI == "mongodb://localhost:27017/furdb"


### PR DESCRIPTION
## Summary
- update `mongo_service` to warn when no MONGODB_URI
- update `fur_mongo` to do the same
- test that both modules load without the env variable

## Testing
- `black mongo_service.py fur_mongo.py tests/test_mongo_defaults.py`
- `isort mongo_service.py fur_mongo.py tests/test_mongo_defaults.py`
- `flake8 mongo_service.py fur_mongo.py tests/test_mongo_defaults.py`
- `pytest --disable-warnings --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_68569dd354b88324a78d841c4156c6c8