### PR TITLE
Update i18n docs for JSON catalogs

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,21 +1,33 @@
 # Internationalization (i18n)
 
-This project uses **Flask-Babel-Next** for translations. Messages reside in the `translations/` folder as `.po` source files and compiled `.mo` files.
+Translations are maintained as JSON files in the `translations/` directory. Each
+file contains key‑value pairs for a specific language (for example
+`de.json`, `en.json`, `fr.json`). The `fur_lang.i18n` module loads these files at
+startup and exposes helper functions:
 
-## PyBabel commands
+```python
+from fur_lang.i18n import t, current_lang, get_supported_languages
 
-```bash
-# Extract messages from the source files
-pybabel extract -F babel.cfg -o messages.pot .
-
-# Initialize a new language, e.g. German
-pybabel init -i messages.pot -d translations -l de
-
-# Update existing locales
-pybabel update -i messages.pot -d translations
-
-# Compile translations for usage in the application
-pybabel compile -d translations
+text = t("Hello")
 ```
 
-Use `gettext` (`_()`), `ngettext` for pluralization and `lazy_gettext` for lazy evaluation inside models or config files. The compiled catalogs are loaded from `translations/<locale>/LC_MESSAGES/`.
+The default and fallback language is German (`de`). Flask‑Babel is still used for
+locale handling but no longer for translation catalogs.
+
+## Maintaining translations
+
+Several helper scripts live in `i18n_tools/` to keep the JSON files in sync:
+
+- `extract_i18n_keys.py` – scan the project for `t("…")` calls and update the
+  key list
+- `generate_key_list.py` – write all keys to `translation_keys.json`
+- `fill_translations.py` and `auto_fill.py` – automatically add missing keys by
+  using online translation services
+- `translate_sync.py` – synchronize and report missing phrases for many
+  languages
+
+Run these scripts from the project root as needed to update the translation
+files. After updating, commit the modified JSON files to version control.
+
+Templates, bots and other modules should use `fur_lang.i18n.t()` rather than
+`gettext`.


### PR DESCRIPTION
## Summary
- update docs to describe JSON-based translations loaded with `fur_lang.i18n`
- list helper scripts in `i18n_tools` for maintaining catalogs

## Testing
- `black .`
- `isort .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685821a04ea083248f8183059aa36c78