### PR TITLE
Add JSON validation test for translations

### DIFF
--- a/tests/test_translations_valid.py
+++ b/tests/test_translations_valid.py
@@ -1,0 +1,12 @@
+import json
+from pathlib import Path
+
+import pytest
+
+TRANSLATIONS_DIR = Path(__file__).resolve().parents[1] / "translations"
+
+
+@pytest.mark.parametrize("path", sorted(TRANSLATIONS_DIR.glob("*.json")))
+def test_translation_file_valid(path):
+    with open(path, encoding="utf-8") as f:
+        json.load(f)


### PR DESCRIPTION
## Summary
- add a simple pytest to verify every JSON file in `translations/` can be loaded

## Testing
- `black . && isort . && flake8`
- `pytest --disable-warnings --maxfail=1`


------
https://chatgpt.com/codex/tasks/task_e_6858218dbdcc83248ffdd1b1f1b2e876