### PR TITLE
Add flag translation check

### DIFF
--- a/fur_lang/i18n.py
+++ b/fur_lang/i18n.py
@@ -14,6 +14,7 @@ from flask import current_app, request, session
 log = logging.getLogger(__name__)
 
 TRANSLATION_FOLDER = os.path.join(os.path.dirname(os.path.dirname(__file__)), "translations")
+FLAG_FOLDER = os.path.join(os.path.dirname(os.path.dirname(__file__)), "static", "flags")
 LANG_FALLBACK = "en"
 
 
@@ -33,6 +34,22 @@ def load_translations(directory=TRANSLATION_FOLDER):
 
 # 📦 Globale Übersetzungstabelle
 translations = load_translations()
+
+
+def warn_flags_without_translation(
+    flag_dir: str = FLAG_FOLDER, translation_dir: str = TRANSLATION_FOLDER
+) -> None:
+    """Log a warning for each flag without matching translation file."""
+    for flag_file in os.listdir(flag_dir):
+        if not flag_file.endswith(".png"):
+            continue
+        lang_code = flag_file[:-4]
+        json_path = os.path.join(translation_dir, f"{lang_code}.json")
+        if not os.path.exists(json_path):
+            log.warning("Flag '%s' found but no %s.json translation.", flag_file, lang_code)
+
+
+warn_flags_without_translation()
 
 
 def get_supported_languages():

--- a/tests/test_flag_translation_check.py
+++ b/tests/test_flag_translation_check.py
@@ -1,0 +1,24 @@
+import importlib
+import logging
+
+from fur_lang import i18n
+
+
+def test_warns_when_flag_missing_translation(tmp_path, caplog):
+    flags_dir = tmp_path / "static" / "flags"
+    flags_dir.mkdir(parents=True)
+    (flags_dir / "xx.png").write_bytes(b"img")
+    translations_dir = tmp_path / "translations"
+    translations_dir.mkdir()
+    (translations_dir / "en.json").write_text("{}")
+
+    caplog.set_level(logging.WARNING)
+
+    importlib.reload(i18n)
+    caplog.clear()
+
+    i18n.warn_flags_without_translation(str(flags_dir), str(translations_dir))
+
+    assert any(
+        "Flag 'xx.png' found but no xx.json translation." in r.message for r in caplog.records
+    )


### PR DESCRIPTION
## Summary
- warn when a flag exists but the language JSON is missing
- test warnings when flag has no translation

## Testing
- `flake8 tests/test_flag_translation_check.py fur_lang/i18n.py`
- `pytest --disable-warnings --maxfail=1 -q`

------
https://chatgpt.com/codex/tasks/task_e_6858326d7a348324b47ed0d2bc4345f7