### PR TITLE
Add reminder opt-out check

### DIFF
--- a/bot/cogs/reminder_cog.py
+++ b/bot/cogs/reminder_cog.py
@@ -10,6 +10,18 @@ from discord.ext import commands, tasks
 from fur_lang.i18n import t
 from mongo_service import get_collection
 
+
+def is_opted_out(user_id: int) -> bool:
+    """Return True if the user opted out of reminders."""
+    uid = str(user_id)
+    if get_collection("reminder_optout").find_one({"discord_id": uid}):
+        return True
+    settings = get_collection("user_settings").find_one(
+        {"discord_id": uid, "reminder_optout": True}
+    )
+    return bool(settings)
+
+
 log = logging.getLogger(__name__)
 
 
@@ -46,6 +58,9 @@ class ReminderCog(commands.Cog):
                     if get_collection("reminders_sent").find_one(
                         {"event_id": event["_id"], "user_id": user_id}
                     ):
+                        continue
+
+                    if is_opted_out(user_id):
                         continue
                     lang = self.get_user_language(user_id)
                     try:

--- a/tests/test_reminder_optout.py
+++ b/tests/test_reminder_optout.py
@@ -1,0 +1,70 @@
+import types
+from datetime import datetime, timedelta
+
+import pytest
+
+from bot.cogs import reminder_autopilot as autopilot_mod
+
+
+class DummyCollection(list):
+    def find(self, *args, **kwargs):
+        return self
+
+    def find_one(self, query):
+        for doc in self:
+            match = True
+            for k, v in query.items():
+                if doc.get(k) != v:
+                    match = False
+                    break
+            if match:
+                return doc
+        return None
+
+    def insert_one(self, doc):
+        self.append(doc)
+
+
+class DummyUser:
+    def __init__(self):
+        self.sent = False
+
+    async def send(self, msg):
+        self.sent = True
+
+
+@pytest.mark.asyncio
+async def test_autopilot_ignores_opted_out_user(monkeypatch):
+    user = DummyUser()
+    bot = types.SimpleNamespace(fetch_user=lambda uid: user)
+    cog = autopilot_mod.ReminderAutopilot.__new__(autopilot_mod.ReminderAutopilot)
+    cog.bot = bot
+
+    async def fake_lang(uid):
+        return "en"
+
+    cog.get_user_language = fake_lang
+
+    now = datetime.utcnow()
+    event = {"_id": 1, "title": "Test", "event_time": now + timedelta(minutes=5)}
+    events_col = DummyCollection([event])
+    participants_col = DummyCollection([{"user_id": "123", "event_id": 1}])
+    sent_col = DummyCollection()
+    optout_col = DummyCollection([{"discord_id": "123"}])
+    user_settings_col = DummyCollection()
+
+    def get_coll(name):
+        return {
+            "events": events_col,
+            "event_participants": participants_col,
+            "reminders_sent": sent_col,
+            "reminder_optout": optout_col,
+            "user_settings": user_settings_col,
+        }[name]
+
+    monkeypatch.setattr(autopilot_mod, "get_collection", get_coll)
+
+    await autopilot_mod.ReminderAutopilot.run_reminder_check(cog)
+
+    assert not user.sent
+    assert sent_col == []


### PR DESCRIPTION
## Summary
- respect reminder opt-out by adding `is_opted_out` helper to reminder cogs
- skip sending reminder DMs when a user has opted out
- test that opted-out users are ignored by the autopilot

## Testing
- `flake8 bot/cogs/reminder_autopilot.py bot/cogs/reminder_cog.py tests/test_reminder_optout.py`
- `pytest tests/test_reminder_optout.py -q`
- `pytest --disable-warnings --maxfail=1 -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6859ac0cd3b88324a052a1378388f9f9