### PR TITLE
Add production check for DM sending

### DIFF
--- a/bot/cogs/dm_broadcast_cog.py
+++ b/bot/cogs/dm_broadcast_cog.py
@@ -8,7 +8,7 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-from config import Config
+from config import Config, is_production
 from fur_lang.i18n import t
 
 log = logging.getLogger(__name__)
@@ -35,6 +35,10 @@ class DMBroadcastCog(commands.Cog):
     )
     @app_commands.describe(text="Nachricht (max 2000 Zeichen)")
     async def dm_all(self, interaction: discord.Interaction, *, text: str) -> None:
+        if not is_production():
+            await interaction.response.send_message("DM skipped in dev mode", ephemeral=True)
+            log.info("DM skipped in dev mode")
+            return
         if not isinstance(interaction.user, discord.Member):
             await interaction.response.send_message(
                 t("dm_broadcast_member_only", default="Nur für Mitglieder verfügbar."),

--- a/bot/cogs/reminder_autopilot.py
+++ b/bot/cogs/reminder_autopilot.py
@@ -7,6 +7,7 @@ import discord
 from discord import app_commands
 from discord.ext import commands, tasks
 
+from config import is_production
 from fur_lang.i18n import t
 from mongo_service import get_collection
 
@@ -43,6 +44,10 @@ class ReminderAutopilot(commands.Cog):
         await self.bot.wait_until_ready()
 
     async def run_reminder_check(self):
+        if not is_production():
+            log.info("DM skipped in dev mode")
+            return
+
         now = datetime.utcnow()
         window_start = now + timedelta(minutes=5)
         window_end = now + timedelta(minutes=6)

--- a/bot/cogs/reminders.py
+++ b/bot/cogs/reminders.py
@@ -8,7 +8,7 @@ import discord
 from discord import app_commands
 from discord.ext import commands, tasks
 
-from config import Config
+from config import Config, is_production
 from fur_lang.i18n import t
 
 log = logging.getLogger(__name__)
@@ -37,6 +37,10 @@ class Reminders(commands.Cog):
     @tasks.loop(minutes=60)
     async def reminder_loop(self):
         """Sendet jede Stunde eine Erinnerungsnachricht an den Reminder-Channel."""
+        if not is_production():
+            log.info("DM skipped in dev mode")
+            return
+
         now = datetime.utcnow().strftime("%H:%M")
         channel = self.bot.get_channel(self.channel_id)
 
@@ -66,6 +70,11 @@ class Reminders(commands.Cog):
     async def reminder_now(self, interaction: discord.Interaction):
         if not interaction.user.guild_permissions.administrator:
             await interaction.response.send_message("🚫 Keine Berechtigung.", ephemeral=True)
+            return
+
+        if not is_production():
+            await interaction.response.send_message("DM skipped in dev mode", ephemeral=True)
+            log.info("DM skipped in dev mode")
             return
 
         channel = self.bot.get_channel(self.channel_id)

--- a/config.py
+++ b/config.py
@@ -115,3 +115,8 @@ class Config:
 
     # --- Web ---
     BASE_URL: str = get_env_str("BASE_URL", default="http://localhost:8080")
+
+
+def is_production() -> bool:
+    """Return True if the app runs in production mode."""
+    return Config.FLASK_ENV == "production"

--- a/tests/test_dm_skip.py
+++ b/tests/test_dm_skip.py
@@ -1,0 +1,25 @@
+import asyncio
+import types
+
+from bot.cogs import reminder_autopilot as autopilot_mod
+
+
+def test_run_reminder_check_skips(monkeypatch):
+    send_called = False
+
+    class FakeUser:
+        async def send(self, msg):
+            nonlocal send_called
+            send_called = True
+
+    class FakeBot:
+        async def fetch_user(self, uid):
+            return FakeUser()
+
+    dummy = types.SimpleNamespace(bot=FakeBot(), get_user_language=lambda uid: "de")
+
+    monkeypatch.setattr(autopilot_mod, "is_production", lambda: False)
+
+    asyncio.run(autopilot_mod.ReminderAutopilot.run_reminder_check(dummy))
+
+    assert send_called is False


### PR DESCRIPTION
## Summary
- add `is_production()` util in config
- skip DM-related sends when not in production
- log skipped actions
- ensure reminder autopilot does not DM in dev mode

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859ac105a6c83249a081d62cf58246c