### PR TITLE
Add error handler Cog for Discord bot

### DIFF
--- a/bot/bot_main.py
+++ b/bot/bot_main.py
@@ -59,6 +59,7 @@ def create_bot() -> commands.Bot:
 async def load_extensions(bot_instance: commands.Bot):
     """Lädt alle aktiven Bot-Cogs."""
     extensions = [
+        "bot.cogs.error_handler",
         "bot.cogs.reminder_autopilot",
         "bot.cogs.reminder_optout",
         "bot.cogs.dm_broadcast_cog",

--- a/bot/cogs/error_handler.py
+++ b/bot/cogs/error_handler.py
@@ -1,0 +1,61 @@
+import logging
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from fur_lang.i18n import t
+
+log = logging.getLogger(__name__)
+
+
+class ErrorHandler(commands.Cog):
+    """Global application command error handler."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    async def _reply(self, interaction: discord.Interaction, message: str) -> None:
+        """Send a response or followup depending on state."""
+        if interaction.response.is_done():
+            await interaction.followup.send(message, ephemeral=True)
+        else:
+            await interaction.response.send_message(message, ephemeral=True)
+
+    @commands.Cog.listener()
+    async def on_application_command_error(
+        self, interaction: discord.Interaction, error: app_commands.AppCommandError
+    ) -> None:
+        """Handle slash command errors with localized messages."""
+        lang = "de"
+        if isinstance(error, commands.MissingPermissions):
+            await self._reply(
+                interaction,
+                t("error_missing_permissions", default="🚫 Missing permissions.", lang=lang),
+            )
+        elif isinstance(error, commands.CommandOnCooldown):
+            await self._reply(
+                interaction,
+                t("error_command_cooldown", default="⏱ Command is on cooldown.", lang=lang),
+            )
+        elif isinstance(error, commands.CommandInvokeError):
+            log.error("CommandInvokeError: %s", error, exc_info=True)
+            await self._reply(
+                interaction,
+                t("error_default_message", default="An error occurred.", lang=lang),
+            )
+        elif isinstance(error, commands.CheckFailure):
+            await self._reply(
+                interaction,
+                t("error_check_failure", default="You cannot use this command.", lang=lang),
+            )
+        else:
+            log.error("Unhandled command error: %s", error, exc_info=True)
+            await self._reply(
+                interaction,
+                t("error_default_message", default="An error occurred.", lang=lang),
+            )
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(ErrorHandler(bot))

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -1,0 +1,68 @@
+import asyncio
+import logging
+
+import discord
+from discord.ext import commands
+
+from bot.cogs.error_handler import ErrorHandler
+from fur_lang.i18n import t
+
+
+class DummyResponse:
+    def __init__(self):
+        self.message = None
+        self._done = False
+
+    async def send_message(self, message, ephemeral=False):
+        self._done = True
+        self.message = message
+
+    def is_done(self):
+        return self._done
+
+
+class DummyFollowup:
+    def __init__(self):
+        self.message = None
+
+    async def send(self, message, ephemeral=False):
+        self.message = message
+
+
+class DummyInteraction:
+    def __init__(self):
+        self.user = type("User", (), {"id": 1})()
+        self.response = DummyResponse()
+        self.followup = DummyFollowup()
+
+
+def run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def test_missing_permissions_message():
+    bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+    handler = ErrorHandler(bot)
+    interaction = DummyInteraction()
+
+    run(handler.on_application_command_error(interaction, commands.MissingPermissions(["admin"])))
+
+    expected = t("error_missing_permissions", default="🚫 Missing permissions.", lang="de")
+    assert interaction.response.message == expected
+
+
+def test_command_invoke_error_logs(caplog):
+    bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+    handler = ErrorHandler(bot)
+    interaction = DummyInteraction()
+
+    with caplog.at_level(logging.ERROR):
+        run(
+            handler.on_application_command_error(
+                interaction, commands.CommandInvokeError(Exception("boom"))
+            )
+        )
+
+    expected = t("error_default_message", default="An error occurred.", lang="de")
+    assert interaction.response.message == expected
+    assert "CommandInvokeError" in caplog.text


### PR DESCRIPTION
## Summary
- add `ErrorHandler` cog to capture slash command errors and respond with localized messages
- register `bot.cogs.error_handler` in bot extension loader
- cover behaviour with unit tests for permission and invocation errors

## Testing
- `black bot/cogs/error_handler.py tests/test_error_handler.py bot/bot_main.py`
- `isort bot/cogs/error_handler.py tests/test_error_handler.py bot/bot_main.py`
- `flake8 bot/cogs/error_handler.py tests/test_error_handler.py bot/bot_main.py`
- `pytest --disable-warnings --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_6859ac207f3c8324988179ea138e70e8