### PR TITLE
Add newsletter autopilot

### DIFF
--- a/bot/bot_main.py
+++ b/bot/bot_main.py
@@ -64,6 +64,7 @@ async def load_extensions(bot_instance: commands.Bot):
         "bot.cogs.dm_broadcast_cog",
         "bot.cogs.base_commands",
         "bot.cogs.leaderboard",
+        "bot.cogs.newsletter_autopilot",
         "bot.cogs.newsletter",
         "bot.cogs.reminders",
         "bot.cogs.reminder_cog",

--- a/bot/cogs/newsletter_autopilot.py
+++ b/bot/cogs/newsletter_autopilot.py
@@ -1,0 +1,107 @@
+"""Auto-send weekly newsletter DMs with upcoming events."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from datetime import datetime, timedelta
+
+import discord
+from discord import app_commands
+from discord.ext import commands, tasks
+
+from config import Config
+from mongo_service import get_collection
+
+log = logging.getLogger(__name__)
+
+
+def should_send_newsletter(dt: datetime) -> bool:
+    """Return True when newsletter should be dispatched."""
+    return dt.weekday() == 6 and dt.hour == 12
+
+
+class NewsletterAutopilot(commands.Cog):
+    """Loop-based newsletter dispatcher."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self.sent = 0
+        self.blocked = 0
+        self.errors = 0
+        self.delay = float(os.getenv("NEWSLETTER_DM_DELAY", "1"))
+        self.enabled = os.getenv("ENABLE_NEWSLETTER_AUTOPILOT", "true").lower() == "true"
+        self.newsletter_loop.start()
+
+    def cog_unload(self) -> None:
+        self.newsletter_loop.cancel()
+
+    @tasks.loop(hours=1)
+    async def newsletter_loop(self) -> None:
+        await self.bot.wait_until_ready()
+        if not self.enabled:
+            return
+        now = datetime.utcnow()
+        if should_send_newsletter(now):
+            await self.send_newsletters()
+
+    async def build_content(self) -> str:
+        now = datetime.utcnow()
+        week_end = now + timedelta(days=7)
+        events = (
+            get_collection("events")
+            .find({"event_time": {"$gte": now, "$lte": week_end}}, {"title": 1, "event_time": 1})
+            .sort("event_time", 1)
+        )
+        lines = ["📰 Upcoming Events"]
+        for ev in events:
+            dt = ev["event_time"]
+            if isinstance(dt, str):
+                try:
+                    dt = datetime.fromisoformat(dt)
+                except ValueError:
+                    continue
+            lines.append(f"- {ev['title']} – {dt.strftime('%d.%m.%Y %H:%M')} UTC")
+        if len(lines) == 1:
+            lines.append("Keine Events in den nächsten 7 Tagen.")
+        return "\n".join(lines)
+
+    async def send_newsletters(self) -> None:
+        guild = self.bot.get_guild(Config.DISCORD_GUILD_ID)
+        if not guild:
+            log.warning("Guild not found for newsletter dispatch")
+            return
+        content = await self.build_content()
+        for member in guild.members:
+            if member.bot:
+                continue
+            if get_collection("newsletter_optout").find_one({"discord_id": str(member.id)}):
+                self.blocked += 1
+                continue
+            try:
+                await member.send(content)
+                self.sent += 1
+            except discord.Forbidden:
+                self.blocked += 1
+                log.warning("DM blocked for %s", member.id)
+            except Exception as exc:  # noqa: BLE001
+                self.errors += 1
+                log.error("Error sending newsletter to %s: %s", member.id, exc)
+            await asyncio.sleep(self.delay)
+
+    @app_commands.command(name="newsletter_now", description="Send newsletter immediately")
+    async def newsletter_now(self, interaction: discord.Interaction) -> None:
+        if not interaction.user.guild_permissions.administrator:
+            await interaction.response.send_message("🚫 Keine Adminrechte.", ephemeral=True)
+            return
+        await interaction.response.defer(ephemeral=True)
+        await self.send_newsletters()
+        await interaction.followup.send(
+            f"Newsletter sent: {self.sent} ✅ / {self.blocked} 🚫 / {self.errors} ❌",
+            ephemeral=True,
+        )
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(NewsletterAutopilot(bot))

--- a/tests/test_newsletter_autopilot.py
+++ b/tests/test_newsletter_autopilot.py
@@ -1,0 +1,75 @@
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+
+import bot.cogs.newsletter_autopilot as mod
+
+
+def test_should_send_newsletter_true():
+    sunday_noon = datetime(2024, 8, 18, 12, 0)
+    assert mod.should_send_newsletter(sunday_noon)
+
+
+def test_should_send_newsletter_false():
+    sunday_late = datetime(2024, 8, 18, 13, 0)
+    monday_noon = datetime(2024, 8, 19, 12, 0)
+    assert not mod.should_send_newsletter(sunday_late)
+    assert not mod.should_send_newsletter(monday_noon)
+
+
+class FakeCollection:
+    def __init__(self, should_block=False):
+        self.should_block = should_block
+
+    def find(self, *a, **kw):
+        return self
+
+    def sort(self, *a, **kw):
+        return [{"title": "Event", "event_time": datetime.utcnow()}]
+
+    def find_one(self, query):
+        if self.should_block:
+            return {"discord_id": query["discord_id"]}
+        return None
+
+
+class FakeMember(SimpleNamespace):
+    bot = False
+
+    async def send(self, *_):
+        self.sent = True
+
+
+class FakeGuild(SimpleNamespace):
+    pass
+
+
+class FakeBot(SimpleNamespace):
+    def get_guild(self, gid):
+        return self.guild
+
+    async def wait_until_ready(self):
+        return
+
+
+@pytest.mark.asyncio
+async def test_opt_out(monkeypatch):
+    guild = FakeGuild(members=[FakeMember(id=1), FakeMember(id=2)])
+    bot = FakeBot(guild=guild)
+
+    def fake_get_collection(name):
+        if name == "newsletter_optout":
+            return FakeCollection(should_block=True)
+        return FakeCollection()
+
+    monkeypatch.setattr(mod.tasks.Loop, "start", lambda self: None)
+    monkeypatch.setattr(mod, "get_collection", fake_get_collection)
+    monkeypatch.setattr(mod.Config, "DISCORD_GUILD_ID", 1)
+
+    cog = mod.NewsletterAutopilot(bot)
+    await cog.send_newsletters()
+
+    # first member blocked, second blocked too because collection returns block
+    assert cog.blocked == 2
+    assert cog.sent == 0


### PR DESCRIPTION
## Summary
- schedule Sunday 12:00 UTC newsletter loop
- gather events for next week and DM members unless they opted out
- allow manual `/newsletter_now` admin command
- cover logic and opt-out behaviour with unit tests

## Testing
- `flake8`
- `pytest --disable-warnings --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_6859ac2e68f08324b6f9f69b848f1d61