### PR TITLE
Add reaction-based event signup

### DIFF
--- a/blueprints/public.py
+++ b/blueprints/public.py
@@ -186,7 +186,12 @@ def view_event(event_id):
     event = db["events"].find_one({"_id": ObjectId(event_id)})
     if not event:
         abort(404)
-    return render_template("public/view_event.html", event=event)
+    participant_docs = list(db["event_participants"].find({"event_id": event["_id"]}))
+    participants = []
+    for p in participant_docs:
+        user = db["users"].find_one({"discord_id": p["user_id"]})
+        participants.append({"username": user.get("username") if user else p["user_id"]})
+    return render_template("public/view_event.html", event=event, participants=participants)
 
 
 @public.route("/events/<event_id>/join", methods=["POST"])

--- a/bot/bot_main.py
+++ b/bot/bot_main.py
@@ -74,6 +74,7 @@ async def load_extensions(bot_instance: commands.Bot):
         "bot.cogs.newsletter",
         "bot.cogs.reminders",
         "bot.cogs.reminder_cog",
+        "bot.cogs.reaction_signup",
         # "bot.cogs.reminder_sender_cog",  # falls später aktiv
     ]
 

--- a/bot/cogs/reaction_signup.py
+++ b/bot/cogs/reaction_signup.py
@@ -1,0 +1,69 @@
+"""reaction_signup.py – Save 🔥 reactions as event participation."""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime
+
+import discord
+from bson import ObjectId
+from discord.ext import commands
+
+from mongo_service import get_collection
+
+log = logging.getLogger(__name__)
+
+EVENT_ID_RE = re.compile(r"\[ID:(?P<id>[a-fA-F0-9]{24})\]")
+
+
+class ReactionSignup(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    async def _extract_event_id(self, message: discord.Message) -> ObjectId | None:
+        match = EVENT_ID_RE.search(message.content)
+        if not match:
+            return None
+        try:
+            return ObjectId(match.group("id"))
+        except Exception:
+            return None
+
+    async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent) -> None:
+        if str(payload.emoji) != "🔥":
+            return
+        channel = self.bot.get_channel(payload.channel_id)
+        if not channel:
+            return
+        try:
+            message = await channel.fetch_message(payload.message_id)
+        except Exception as exc:  # noqa: BLE001
+            log.warning("Could not fetch message: %s", exc)
+            return
+
+        event_id = await self._extract_event_id(message)
+        if not event_id:
+            return
+
+        if not get_collection("events").find_one({"_id": event_id}):
+            log.warning("Invalid event id %s", event_id)
+            return
+
+        collection = get_collection("event_participants")
+        collection.update_one(
+            {"event_id": event_id, "user_id": str(payload.user_id)},
+            {
+                "$setOnInsert": {
+                    "event_id": event_id,
+                    "user_id": str(payload.user_id),
+                    "joined_at": datetime.utcnow(),
+                }
+            },
+            upsert=True,
+        )
+        log.info("User %s joined event %s via reaction", payload.user_id, event_id)
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(ReactionSignup(bot))

--- a/schemas/event_schema.py
+++ b/schemas/event_schema.py
@@ -23,6 +23,12 @@ class PyObjectId(ObjectId):
     def __modify_schema__(cls, field_schema):
         field_schema.update(type="string")
 
+    @classmethod
+    def __get_pydantic_json_schema__(cls, core_schema, handler):
+        schema = handler(core_schema)
+        schema.update(type="string")
+        return schema
+
 
 # Hauptmodell für Events
 class EventModel(BaseModel):

--- a/tests/test_reaction_signup.py
+++ b/tests/test_reaction_signup.py
@@ -1,0 +1,58 @@
+import asyncio
+import types
+
+from bson import ObjectId
+
+import bot.cogs.reaction_signup as rs_mod
+
+
+class DummyMessage:
+    def __init__(self, content):
+        self.content = content
+
+
+class DummyChannel:
+    async def fetch_message(self, message_id):
+        return DummyMessage("Event [ID:507f1f77bcf86cd799439011]")
+
+
+class DummyBot:
+    def get_channel(self, cid):
+        return DummyChannel()
+
+
+class DummyCollection(list):
+    def find_one(self, query):
+        if query.get("_id"):
+            return {"_id": query["_id"]}
+        return None
+
+    def update_one(self, flt, update, upsert=False):
+        self.append(flt)
+
+
+def test_reaction_signup(monkeypatch):
+    events_col = DummyCollection()
+    participants_col = DummyCollection()
+
+    def get_coll(name):
+        return {"events": events_col, "event_participants": participants_col}[name]
+
+    monkeypatch.setattr(rs_mod, "get_collection", get_coll)
+
+    bot = DummyBot()
+    cog = rs_mod.ReactionSignup(bot)
+
+    payload = types.SimpleNamespace(
+        emoji=types.SimpleNamespace(__str__=lambda self: "🔥"),
+        channel_id=1,
+        message_id=2,
+        user_id=123,
+    )
+
+    asyncio.run(cog.on_raw_reaction_add(payload))
+
+    assert participants_col[0] == {
+        "event_id": ObjectId("507f1f77bcf86cd799439011"),
+        "user_id": "123",
+    }


### PR DESCRIPTION
## Summary
- create `ReactionSignup` cog to store 🔥 reactions as event participants
- load new cog in `bot_main`
- list event participants on public event view
- show participants in admin page
- support pydantic v2 in event schema
- test reaction signup logic

## Testing
- `flake8`
- `pytest --disable-warnings --maxfail=1 -q` *(fails: RuntimeError: There is no current event loop in thread 'MainThread')*

------
https://chatgpt.com/codex/tasks/task_e_6859bd855d5c832499cc34030aa4032c