### PR TITLE
Add daily overview to newsletter autopilot

### DIFF
--- a/tests/test_newsletter_autopilot.py
+++ b/tests/test_newsletter_autopilot.py
@@ -73,3 +73,31 @@ async def test_opt_out(monkeypatch):
     # first member blocked, second blocked too because collection returns block
     assert cog.blocked == 2
     assert cog.sent == 0
+
+
+def test_should_send_daily_overview():
+    morning = datetime(2024, 8, 19, 8, 0)
+    assert mod.should_send_daily_overview(morning)
+    later = datetime(2024, 8, 19, 9, 0)
+    assert not mod.should_send_daily_overview(later)
+
+
+@pytest.mark.asyncio
+async def test_daily_opt_out(monkeypatch):
+    guild = FakeGuild(members=[FakeMember(id=1), FakeMember(id=2)])
+    bot = FakeBot(guild=guild)
+
+    def fake_get_collection(name):
+        if name == "newsletter_optout":
+            return FakeCollection(should_block=True)
+        return FakeCollection()
+
+    monkeypatch.setattr(mod.tasks.Loop, "start", lambda self: None)
+    monkeypatch.setattr(mod, "get_collection", fake_get_collection)
+    monkeypatch.setattr(mod.Config, "DISCORD_GUILD_ID", 1)
+
+    cog = mod.NewsletterAutopilot(bot)
+    await cog.send_daily_overview()
+
+    assert cog.blocked == 2
+    assert cog.sent == 0


### PR DESCRIPTION
## Summary
- extend `newsletter_autopilot` with a loop that checks for 08 UTC
- send a daily overview DM similar to the weekly newsletter
- update tests for the new daily feature

## Testing
- `black .`
- `isort .`
- `flake8 .`
- `pytest --disable-warnings --maxfail=1` *(fails: RuntimeError: There is no current event loop in thread 'MainThread')*

------
https://chatgpt.com/codex/tasks/task_e_6859cff733648324966d7ef0aa8a6ea2