### PR TITLE
Add event helper utilities and integrate with newsletter/reminder

### DIFF
--- a/bot/cogs/newsletter_autopilot.py
+++ b/bot/cogs/newsletter_autopilot.py
@@ -13,6 +13,7 @@ from discord.ext import commands, tasks
 
 from config import Config
 from mongo_service import get_collection
+from utils.event_helpers import format_events, get_events_for
 
 log = logging.getLogger(__name__)
 
@@ -48,23 +49,16 @@ class NewsletterAutopilot(commands.Cog):
 
     async def build_content(self) -> str:
         now = datetime.utcnow()
-        week_end = now + timedelta(days=7)
-        events = (
-            get_collection("events")
-            .find({"event_time": {"$gte": now, "$lte": week_end}}, {"title": 1, "event_time": 1})
-            .sort("event_time", 1)
-        )
+        events: list[dict] = []
+        for i in range(7):
+            events.extend(get_events_for(now + timedelta(days=i)))
+
         lines = ["📰 Upcoming Events"]
-        for ev in events:
-            dt = ev["event_time"]
-            if isinstance(dt, str):
-                try:
-                    dt = datetime.fromisoformat(dt)
-                except ValueError:
-                    continue
-            lines.append(f"- {ev['title']} – {dt.strftime('%d.%m.%Y %H:%M')} UTC")
-        if len(lines) == 1:
+        if events:
+            lines.append(format_events(events))
+        else:
             lines.append("Keine Events in den nächsten 7 Tagen.")
+
         return "\n".join(lines)
 
     async def send_newsletters(self) -> None:

--- a/bot/cogs/reminder_cog.py
+++ b/bot/cogs/reminder_cog.py
@@ -9,6 +9,7 @@ from discord.ext import commands, tasks
 
 from fur_lang.i18n import t
 from mongo_service import get_collection
+from utils.event_helpers import get_events_for, parse_event_time
 
 
 def is_opted_out(user_id: int) -> bool:
@@ -48,9 +49,15 @@ class ReminderCog(commands.Cog):
         window_end = now + timedelta(minutes=15)
 
         try:
-            events = get_collection("events").find(
-                {"event_time": {"$gte": window_start, "$lte": window_end}}
-            )
+            today_events = get_events_for(now)
+            events = [
+                ev
+                for ev in today_events
+                if (
+                    (ev_time := parse_event_time(ev.get("event_time")))
+                    and window_start <= ev_time <= window_end
+                )
+            ]
             for event in events:
                 participants = get_collection("participants").find({"event_id": event["_id"]})
                 for p in participants:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Pytest configuration for FUR system using MongoDB."""
 
+import asyncio
 import os
 
 import pytest
@@ -18,6 +19,21 @@ os.environ.setdefault("R3_ROLE_IDS", "1")
 os.environ.setdefault("R4_ROLE_IDS", "1")
 os.environ.setdefault("ADMIN_ROLE_IDS", "1")
 os.environ.setdefault("BASE_URL", "http://localhost:8080")
+
+try:
+    asyncio.get_event_loop()
+except RuntimeError:
+    asyncio.set_event_loop(asyncio.new_event_loop())
+
+
+@pytest.fixture(autouse=True)
+def ensure_loop():
+    try:
+        asyncio.get_event_loop()
+    except RuntimeError:
+        asyncio.set_event_loop(asyncio.new_event_loop())
+    yield
+
 
 import web  # noqa: E402
 from flask_babel_next import Babel as _BaseBabel  # noqa: E402

--- a/tests/test_event_helpers.py
+++ b/tests/test_event_helpers.py
@@ -1,0 +1,45 @@
+from datetime import datetime
+
+import utils.event_helpers as mod
+
+
+class FakeEvents:
+    def __init__(self, docs):
+        self.docs = docs
+
+    def find(self, query):
+        self.query = query
+        return self
+
+    def sort(self, *_, **__):
+        start = self.query["event_time"]["$gte"]
+        end = self.query["event_time"]["$lt"]
+        result = [d for d in self.docs if start <= d["event_time"] < end]
+        return sorted(result, key=lambda d: d["event_time"])
+
+
+def fake_get_collection(name):
+    return FakeEvents(
+        [
+            {"title": "A", "event_time": datetime(2025, 1, 1, 10, 0)},
+            {"title": "B", "event_time": datetime(2025, 1, 2, 12, 0)},
+        ]
+    )
+
+
+def test_get_events_for(monkeypatch):
+    monkeypatch.setattr(mod, "get_collection", fake_get_collection)
+    events = mod.get_events_for(datetime(2025, 1, 1))
+    assert len(events) == 1
+    assert events[0]["title"] == "A"
+
+
+def test_format_events():
+    events = [
+        {"title": "X", "event_time": datetime(2025, 1, 1, 8, 0)},
+        {"title": "Y", "event_time": "2025-01-02T09:00:00"},
+    ]
+    text = mod.format_events(events)
+    assert "- X" in text
+    assert "01.01.2025" in text
+    assert "02.01.2025" in text

--- a/utils/event_helpers.py
+++ b/utils/event_helpers.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from datetime import date as date_type
+from datetime import datetime, timedelta
+from typing import Any, Iterable
+
+from mongo_service import get_collection
+
+
+def parse_event_time(value: Any) -> datetime | None:
+    """Return ``datetime`` for event_time field or ``None`` if invalid."""
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            return None
+    return None
+
+
+def get_events_for(dt: datetime | date_type) -> list[dict]:
+    """Return all events for the given day sorted by ``event_time``."""
+    if isinstance(dt, datetime):
+        day = dt.date()
+    else:
+        day = dt
+    start = datetime.combine(day, datetime.min.time())
+    end = start + timedelta(days=1)
+    events = (
+        get_collection("events")
+        .find({"event_time": {"$gte": start, "$lt": end}})
+        .sort("event_time", 1)
+    )
+    return list(events)
+
+
+def format_events(events: Iterable[dict]) -> str:
+    """Return a newline separated bullet list for the given events."""
+    lines = []
+    for ev in events:
+        dt = parse_event_time(ev.get("event_time"))
+        if not dt:
+            continue
+        title = ev.get("title", "Event")
+        lines.append(f"- {title} – {dt.strftime('%d.%m.%Y %H:%M')} UTC")
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary
- provide `utils/event_helpers.py` with helper functions
- integrate event helpers in reminder and newsletter cogs
- fix tests by ensuring an event loop exists
- add unit tests for the new helpers

## Testing
- `pip install -r requirements.txt`
- `black .`
- `isort .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859cff9ae408324bf1df5dc6b5d02fc