### PR TITLE
Add Google Calendar sync module

### DIFF
--- a/agents/scheduler_agent.py
+++ b/agents/scheduler_agent.py
@@ -8,6 +8,7 @@ import time
 import schedule
 
 from champion.autopilot import run_champion_autopilot
+from utils.google_sync import sync_google_calendar
 
 
 class SchedulerAgent:
@@ -34,3 +35,13 @@ class SchedulerAgent:
         )
         self.jobs.append(job)
         logging.info("\U0001f4c5 Champion Autopilot every %s hours scheduled", interval_hours)
+
+    def schedule_google_sync(self, interval_minutes: int = 30) -> None:
+        """Schedule regular Google Calendar synchronization."""
+
+        job = schedule.every(interval_minutes).minutes.do(sync_google_calendar)
+        self.jobs.append(job)
+        logging.info(
+            "\U0001f4c5 Google Calendar sync every %s minutes scheduled",
+            interval_minutes,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ dependencies = [
   "pydantic>=2.6.4",
   "Flask-Babel>=2.0.0",
   "python-dotenv>=1.0.1",
-  "Markdown>=3.0"
+  "Markdown>=3.0",
+  "google-api-python-client>=2.125.0"
 ]
 
 [tool.setuptools]

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,7 @@ setuptools==80.7.1
 types-python-dateutil==2.9.0.20250516
 aiodns>=3.5.0
 bleach>=6.0
+google-api-python-client>=2.125.0
 
 # 🧪 Dev & Testing
 pytest>=7.0.0

--- a/tests/test_google_sync.py
+++ b/tests/test_google_sync.py
@@ -1,0 +1,57 @@
+import mongo_service
+import utils.google_sync as mod
+
+
+def test_import_events_upserts():
+    col = mongo_service.db["events"]
+    col.delete_many({})
+
+    events = [
+        {
+            "id": "g1",
+            "summary": "Test",
+            "start": {"dateTime": "2025-01-01T10:00:00Z"},
+            "updated": "2025-01-01T09:00:00Z",
+        }
+    ]
+    mod.import_events(events)
+    assert col.count_documents({"google_id": "g1"}) == 1
+
+    events2 = [
+        {
+            "id": "g1",
+            "summary": "Test2",
+            "start": {"dateTime": "2025-01-01T12:00:00Z"},
+            "updated": "2025-01-02T09:00:00Z",
+        }
+    ]
+    mod.import_events(events2)
+    doc = col.find_one({"google_id": "g1"})
+    assert doc["title"] == "Test2"
+
+
+def test_sync_google_calendar(monkeypatch):
+    called = {}
+
+    def fake_fetch(service, calendar_id):
+        called["calendar_id"] = calendar_id
+        return [
+            {
+                "id": "g2",
+                "summary": "Meet",
+                "start": {"date": "2025-01-02"},
+                "updated": "2025-01-01T11:00:00Z",
+            }
+        ]
+
+    def fake_import(events):
+        called["imported"] = events
+
+    monkeypatch.setattr(mod, "get_service", lambda: object())
+    monkeypatch.setattr(mod, "fetch_calendar_events", fake_fetch)
+    monkeypatch.setattr(mod, "import_events", fake_import)
+    monkeypatch.setenv("GOOGLE_CALENDAR_ID", "test")
+
+    mod.sync_google_calendar()
+    assert called["calendar_id"] == "test"
+    assert called["imported"][0]["id"] == "g2"

--- a/utils/google_sync.py
+++ b/utils/google_sync.py
@@ -1,0 +1,99 @@
+"""Helpers to sync events from Google Calendar into MongoDB."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime
+from typing import Iterable
+
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+
+from mongo_service import get_collection
+
+log = logging.getLogger(__name__)
+SCOPES = ["https://www.googleapis.com/auth/calendar.readonly"]
+
+
+def get_service():
+    """Return a Calendar API service or ``None`` if credentials are missing."""
+    creds_json = os.getenv("GOOGLE_CREDENTIALS_JSON")
+    if not creds_json:
+        log.warning("GOOGLE_CREDENTIALS_JSON not set – skipping Google sync")
+        return None
+    info = json.loads(creds_json)
+    creds = service_account.Credentials.from_service_account_info(info, scopes=SCOPES)
+    return build("calendar", "v3", credentials=creds, cache_discovery=False)
+
+
+def fetch_calendar_events(
+    service, calendar_id: str, time_min: datetime | None = None
+) -> list[dict]:
+    """Fetch events from Google Calendar."""
+    if not service:
+        return []
+    events: list[dict] = []
+    page_token = None
+    params = {
+        "calendarId": calendar_id,
+        "singleEvents": True,
+        "orderBy": "updated",
+    }
+    if time_min:
+        params["timeMin"] = time_min.isoformat() + "Z"
+    while True:
+        if page_token:
+            params["pageToken"] = page_token
+        result = service.events().list(**params).execute()
+        events.extend(result.get("items", []))
+        page_token = result.get("nextPageToken")
+        if not page_token:
+            break
+    return events
+
+
+def _parse_start(event: dict) -> datetime | None:
+    start = event.get("start", {}).get("dateTime") or event.get("start", {}).get("date")
+    if not start:
+        return None
+    try:
+        if start.endswith("Z"):
+            start = start.replace("Z", "+00:00")
+        return datetime.fromisoformat(start)
+    except ValueError:
+        return None
+
+
+def import_events(events: Iterable[dict]) -> None:
+    """Upsert events into MongoDB."""
+    collection = get_collection("events")
+    for e in events:
+        doc = {
+            "title": e.get("summary", "No Title"),
+            "description": e.get("description"),
+            "google_id": e.get("id"),
+            "updated": e.get("updated"),
+            "event_time": _parse_start(e),
+        }
+        if not doc["google_id"]:
+            continue
+        collection.update_one({"google_id": doc["google_id"]}, {"$set": doc}, upsert=True)
+
+
+def sync_google_calendar() -> None:
+    """Synchronize events from Google Calendar into MongoDB."""
+    calendar_id = os.getenv("GOOGLE_CALENDAR_ID")
+    if not calendar_id:
+        log.warning("GOOGLE_CALENDAR_ID not set – skipping Google sync")
+        return
+    service = get_service()
+    if not service:
+        return
+    events = fetch_calendar_events(service, calendar_id)
+    if events:
+        import_events(events)
+        log.info("Imported %s Google calendar events", len(events))
+    else:
+        log.info("No Google calendar events fetched")


### PR DESCRIPTION
## Summary
- add Google Calendar sync logic
- schedule periodic sync in `SchedulerAgent`
- include `google-api-python-client` dependency
- test Google sync helpers

## Testing
- `flake8 utils/google_sync.py agents/scheduler_agent.py tests/test_google_sync.py`
- `pytest -q` *(fails: async def functions are not natively supported)*


------
https://chatgpt.com/codex/tasks/task_e_685b29f86e08832494e398a2c6ab6083