### PR TITLE
Add login-protected resources download section

### DIFF
--- a/blueprints/resources.py
+++ b/blueprints/resources.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import os
+
+from flask import Blueprint, abort, current_app, render_template, send_from_directory
+
+from web.auth.decorators import login_required
+
+resources = Blueprint("resources", __name__)
+
+# Example resource files with translation keys for their descriptions
+RESOURCE_FILES = [
+    {"filename": "example.txt", "desc_key": "example_desc"},
+]
+
+
+@resources.route("/resources")
+@login_required
+def list_resources():
+    folder = current_app.config.get("RESOURCES_FOLDER")
+    os.makedirs(folder, exist_ok=True)
+    files = []
+    for res in RESOURCE_FILES:
+        if os.path.exists(os.path.join(folder, res["filename"])):
+            files.append(res)
+    return render_template("resources/index.html", resources=files)
+
+
+@resources.route("/resources/download/<path:filename>")
+@login_required
+def download_resource(filename: str):
+    folder = current_app.config.get("RESOURCES_FOLDER")
+    allowed = {r["filename"] for r in RESOURCE_FILES}
+    safe_name = os.path.basename(filename)
+    if safe_name not in allowed:
+        abort(404)
+    return send_from_directory(folder, safe_name, as_attachment=True)

--- a/config.py
+++ b/config.py
@@ -74,6 +74,7 @@ class Config:
     # --- Upload & Poster ---
     STATIC_FOLDER: str = os.path.join(basedir, "static")
     UPLOAD_FOLDER: str = os.path.join(STATIC_FOLDER, "uploads")
+    RESOURCES_FOLDER: str = os.path.join(STATIC_FOLDER, "resources")
     ALLOWED_EXTENSIONS: set[str] = {"jpg", "png"}
     MAX_CONTENT_LENGTH: int = 2 * 1024 * 1024
 

--- a/static/resources/example.txt
+++ b/static/resources/example.txt
@@ -1,0 +1,1 @@
+Example content

--- a/templates/resources/index.html
+++ b/templates/resources/index.html
@@ -1,0 +1,25 @@
+{% extends "layout.html" %}
+{% set bg_image = "/static/bg/downloads_member.png" %}
+{% block title %}{{ t("Resources") }}{% endblock %}
+
+{% block content %}
+  <div class="main-content">
+    <h2>📦 {{ t("Resource Downloads") }}</h2>
+    <div class="panel">
+      {% if resources %}
+        <ul style="list-style: none; padding: 0;">
+          {% for res in resources %}
+            <li style="margin-bottom: 0.6rem;">
+              <a class="btn" href="{{ url_for('resources.download_resource', filename=res.filename) }}">
+                📄 {{ res.filename }}
+              </a>
+              <p>{{ t(res.desc_key) }}</p>
+            </li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        <p>🚫 {{ t("No resources available.") }}</p>
+      {% endif %}
+    </div>
+  </div>
+{% endblock %}

--- a/tests/test_resources_blueprint.py
+++ b/tests/test_resources_blueprint.py
@@ -1,0 +1,23 @@
+from io import BytesIO
+
+from tests.test_admin_auth import login_with_role
+
+
+def test_resources_requires_login(client):
+    client.get("/logout")
+    resp = client.get("/resources")
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/login")
+
+
+def test_resources_listing_and_download(client, tmp_path):
+    client.application.config.update(RESOURCES_FOLDER=str(tmp_path))
+    file = tmp_path / "example.txt"
+    file.write_text("hello")
+    login_with_role(client, "R3")
+    resp = client.get("/resources")
+    assert resp.status_code == 200
+    assert b"example.txt" in resp.data
+    resp = client.get("/resources/download/example.txt")
+    assert resp.status_code == 200
+    assert resp.data == b"hello"

--- a/translations/de.json
+++ b/translations/de.json
@@ -76,6 +76,10 @@
     "Keine Daten verfügbar": "Keine Daten verfügbar",
     "Keine Daten vorhanden.": "Keine Daten vorhanden.",
     "Keine Downloads verfügbar.": "Keine Downloads verfügbar.",
+    "No resources available.": "Keine Ressourcen verfügbar.",
+    "Resources": "Ressourcen",
+    "Resource Downloads": "Ressourcen",
+    "example_desc": "Beispieldatei"
     "Keine Dateien verfügbar.": "Keine Dateien verfügbar.",
     "Keine Einträge": "Keine Einträge",
     "Keine Einträge in dieser Kategorie.": "Keine Einträge in dieser Kategorie.",

--- a/translations/en.json
+++ b/translations/en.json
@@ -76,6 +76,10 @@
     "Keine Daten verfügbar": "Keine Daten verfügbar",
     "Keine Daten vorhanden.": "No data available.",
     "Keine Downloads verfügbar.": "Keine Downloads verfügbar.",
+    "No resources available.": "No resources available.",
+    "Resources": "Resources",
+    "Resource Downloads": "Resource Downloads",
+    "example_desc": "Example resource file"
     "Keine Dateien verfügbar.": "Keine Dateien verfügbar.",
     "Keine Einträge": "No entries",
     "Keine Einträge in dieser Kategorie.": "Keine Einträge in dieser Kategorie.",

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -105,6 +105,7 @@ def create_app() -> Flask:
         from blueprints.leaderboard import leaderboard
         from blueprints.member import member
         from blueprints.public import public
+        from blueprints.resources import resources as resources_bp
         from dashboard.routes import dashboard
 
         try:
@@ -116,6 +117,7 @@ def create_app() -> Flask:
         app.register_blueprint(member, url_prefix="/members")
         app.register_blueprint(admin, url_prefix="/admin")
         app.register_blueprint(leaderboard, url_prefix="/leaderboard")
+        app.register_blueprint(resources_bp)
         if reminder_api:
             app.register_blueprint(reminder_api, url_prefix="/api/reminders")
         app.register_blueprint(dashboard)


### PR DESCRIPTION
## Summary
- add `resources` blueprint to serve downloadable files
- create template for resources listing
- register blueprint in `web/__init__.py`
- define `RESOURCES_FOLDER` in config
- provide default translation entries and example file
- cover blueprint with unit tests

## Testing
- `isort .`
- `black .`
- `flake8`
- `pytest --disable-warnings --maxfail=1 -q` *(fails: test_translator_command_name)*

------
https://chatgpt.com/codex/tasks/task_e_685b29fda3348324b9cd4c446d1aa8f6