### PR TITLE
Add role-based admin nav visibility

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -115,14 +115,21 @@
     <h2>{{ t("Navigation") }}</h2>
     <a href="{{ url_for('public.landing') }}">🏠 {{ t("Home") }}</a>
     <a href="{{ url_for('public.dashboard') }}">📊 {{ t("Dashboard") }}</a>
+    {% set role = session.get('user', {}).get('role_level') %}
+    {% if role in ['R4', 'ADMIN'] %}
     <a href="{{ url_for('admin.dashboard') }}">🛠️ {{ t("Admin") }}</a>
+    {% endif %}
+    {% if role in ['R3', 'R4', 'ADMIN'] %}
     <a href="{{ url_for('member.dashboard') }}">👥 {{ t("Mitglieder") }}</a>
+    {% endif %}
     <a href="{{ url_for('public.events') }}">📅 {{ t("Events") }}</a>
     <a href="{{ url_for('public.leaderboard') }}">🏆 {{ t("Leaderboard") }}</a>
     <a href="{{ url_for('public.hall_of_fame') }}">👑 {{ t("Hall of Fame") }}</a>
     <a href="{{ url_for('public.lore') }}">📖 {{ t("Lore") }}</a>
+    {% if role in ['R4', 'ADMIN'] %}
     <a href="{{ url_for('admin.upload') }}">⏫ {{ t("Uploads") }}</a>
-    {% if session.get('user', {}).get('role_level') == 'ADMIN' %}
+    {% endif %}
+    {% if role == 'ADMIN' %}
     <a href="{{ url_for('admin_memory.index') }}">🧠 {{ t("Memory") }}</a>
     {% endif %}
   </aside>

--- a/tests/test_nav_rendering.py
+++ b/tests/test_nav_rendering.py
@@ -1,0 +1,57 @@
+import pytest
+
+
+def login_role(client, role: str) -> None:
+    with client.session_transaction() as sess:
+        sess["user"] = {"role_level": role}
+        sess["discord_roles"] = [role]
+
+
+def clear_session(client) -> None:
+    with client.session_transaction() as sess:
+        sess.clear()
+
+
+def get_nav_html(client) -> str:
+    resp = client.get("/calendar")
+    assert resp.status_code == 200
+    return resp.data.decode()
+
+
+def test_nav_guest_hidden(client):
+    clear_session(client)
+    html = get_nav_html(client)
+    assert "/admin/dashboard" not in html
+    assert "/members/dashboard" not in html
+    assert "/admin/upload" not in html
+    assert "/admin/memory" not in html
+
+
+def test_nav_r3_sees_member_only(client):
+    clear_session(client)
+    login_role(client, "R3")
+    html = get_nav_html(client)
+    assert "/members/dashboard" in html
+    assert "/admin/dashboard" not in html
+    assert "/admin/upload" not in html
+    assert "/admin/memory" not in html
+
+
+def test_nav_r4_sees_admin(client):
+    clear_session(client)
+    login_role(client, "R4")
+    html = get_nav_html(client)
+    assert "/members/dashboard" in html
+    assert "/admin/dashboard" in html
+    assert "/admin/upload" in html
+    assert "/admin/memory" not in html
+
+
+def test_nav_admin_sees_all(client):
+    clear_session(client)
+    login_role(client, "ADMIN")
+    html = get_nav_html(client)
+    assert "/members/dashboard" in html
+    assert "/admin/dashboard" in html
+    assert "/admin/upload" in html
+    assert "/admin/memory" in html


### PR DESCRIPTION
## Summary
- restrict admin menu items by user role
- test navigation rendering for different role levels

## Testing
- `pytest tests/test_nav_rendering.py -q`
- `pytest -q` *(fails: async def functions not supported)*

------
https://chatgpt.com/codex/tasks/task_e_685b29fd41588324b22977ac3d028a8e