### PR TITLE
Update google sync fields

### DIFF
--- a/tests/test_google_sync.py
+++ b/tests/test_google_sync.py
@@ -10,24 +10,35 @@ def test_import_events_upserts():
         {
             "id": "g1",
             "summary": "Test",
+            "description": "foo",
+            "location": "bar",
             "start": {"dateTime": "2025-01-01T10:00:00Z"},
+            "end": {"dateTime": "2025-01-01T11:00:00Z"},
             "updated": "2025-01-01T09:00:00Z",
         }
     ]
     mod.import_events(events)
-    assert col.count_documents({"google_id": "g1"}) == 1
+    assert col.count_documents({"google_event_id": "g1"}) == 1
 
     events2 = [
         {
             "id": "g1",
             "summary": "Test2",
+            "description": "baz",
+            "location": "qux",
             "start": {"dateTime": "2025-01-01T12:00:00Z"},
+            "end": {"dateTime": "2025-01-01T13:00:00Z"},
             "updated": "2025-01-02T09:00:00Z",
         }
     ]
     mod.import_events(events2)
-    doc = col.find_one({"google_id": "g1"})
+    doc = col.find_one({"google_event_id": "g1"})
     assert doc["title"] == "Test2"
+    assert doc["start"].hour == 12
+    assert doc["end"].hour == 13
+    assert doc["description"] == "baz"
+    assert doc["location"] == "qux"
+    assert doc["source"] == "google"
 
 
 def test_sync_google_calendar(monkeypatch):

--- a/utils/google_sync.py
+++ b/utils/google_sync.py
@@ -54,14 +54,17 @@ def fetch_calendar_events(
     return events
 
 
-def _parse_start(event: dict) -> datetime | None:
-    start = event.get("start", {}).get("dateTime") or event.get("start", {}).get("date")
-    if not start:
+def _parse_datetime(info: dict | None) -> datetime | None:
+    """Return ``datetime`` from Google date dict or ``None`` if invalid."""
+    if not info:
+        return None
+    value = info.get("dateTime") or info.get("date")
+    if not value:
         return None
     try:
-        if start.endswith("Z"):
-            start = start.replace("Z", "+00:00")
-        return datetime.fromisoformat(start)
+        if value.endswith("Z"):
+            value = value.replace("Z", "+00:00")
+        return datetime.fromisoformat(value)
     except ValueError:
         return None
 
@@ -73,13 +76,19 @@ def import_events(events: Iterable[dict]) -> None:
         doc = {
             "title": e.get("summary", "No Title"),
             "description": e.get("description"),
-            "google_id": e.get("id"),
+            "location": e.get("location"),
+            "google_event_id": e.get("id"),
             "updated": e.get("updated"),
-            "event_time": _parse_start(e),
+            "start": _parse_datetime(e.get("start")),
+            "end": _parse_datetime(e.get("end")),
+            "event_time": _parse_datetime(e.get("start")),
+            "source": "google",
         }
-        if not doc["google_id"]:
+        if not doc["google_event_id"]:
             continue
-        collection.update_one({"google_id": doc["google_id"]}, {"$set": doc}, upsert=True)
+        collection.update_one(
+            {"google_event_id": doc["google_event_id"]}, {"$set": doc}, upsert=True
+        )
 
 
 def sync_google_calendar() -> None:


### PR DESCRIPTION
## Summary
- enhance `google_sync.import_events` to store additional Google event fields and rename `google_id`
- check for these new fields in `tests/test_google_sync.py`

## Testing
- `flake8 utils/google_sync.py tests/test_google_sync.py`
- `pytest tests/test_google_sync.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685b32d9b8c88324b8fa4ae46eb66897