### PR TITLE
Add poster-based daily/weekly reminders

### DIFF
--- a/tests/test_reminder_timings.py
+++ b/tests/test_reminder_timings.py
@@ -2,6 +2,8 @@ import asyncio
 import types
 from datetime import datetime, timedelta
 
+import pytest
+
 from bot.cogs import reminder_autopilot as autopilot_mod
 from bot.cogs import reminder_cog as cog_mod
 from config import Config
@@ -9,6 +11,9 @@ from config import Config
 
 class DummyCollection(list):
     def find(self, *args, **kwargs):
+        return self
+
+    def sort(self, *args, **kwargs):
         return self
 
     def find_one(self, query):
@@ -106,3 +111,50 @@ def test_reminder_cog_sends_60min(monkeypatch):
 
     assert user.sent and "<@&" not in user.sent
     assert len(sent_col) == 1
+
+
+class FileCaptureUser:
+    def __init__(self):
+        self.kwargs = None
+        self.bot = False
+        self.id = 1
+
+    async def send(self, *args, **kwargs):
+        self.kwargs = kwargs
+
+
+@pytest.mark.asyncio
+async def test_daily_poster_attachment(monkeypatch, tmp_path):
+    member = FileCaptureUser()
+    guild = types.SimpleNamespace(members=[member])
+    bot = types.SimpleNamespace(get_guild=lambda gid: guild)
+
+    def fake_get_collection(name):
+        if name == "events":
+            now = datetime.utcnow()
+            return DummyCollection(
+                [
+                    {"title": "Event", "event_time": now.isoformat()},
+                ]
+            )
+        return DummyCollection()
+
+    poster_file = tmp_path / "poster.png"
+    poster_file.write_bytes(b"img")
+
+    monkeypatch.setattr(autopilot_mod.tasks.Loop, "start", lambda self: None)
+    monkeypatch.setattr(autopilot_mod, "get_collection", fake_get_collection)
+    monkeypatch.setattr(autopilot_mod.Config, "DISCORD_GUILD_ID", 1)
+    monkeypatch.setattr(autopilot_mod, "is_opted_out", lambda uid: False)
+    monkeypatch.setattr(
+        autopilot_mod.poster_generator,
+        "generate_poster",
+        lambda *a, **k: str(poster_file),
+    )
+    monkeypatch.setattr(autopilot_mod.discord, "File", lambda p: {"path": p})
+
+    cog = autopilot_mod.ReminderAutopilot(bot)
+    await cog.send_daily_poster()
+
+    assert member.kwargs["file"]["path"] == str(poster_file)
+    assert not member.kwargs.get("content")

--- a/utils/poster_generator.py
+++ b/utils/poster_generator.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+from PIL import Image, ImageDraw, ImageFont
+
+from config import Config
+
+DEFAULT_BG_COLOR = Config.CHAMPION_BG_COLOR
+TITLE_COLOR = Config.CHAMPION_TEXT_COLOR
+TEXT_COLOR = Config.CHAMPION_SUBTEXT_COLOR
+
+
+def generate_poster(title: str, lines: list[str], output_dir: str | None = None) -> str:
+    """Create a simple poster image with a title and lines of text."""
+    out_dir = Path(output_dir or Config.STATIC_FOLDER) / Config.POSTER_OUTPUT_REL_PATH
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    file_path = out_dir / f"{uuid.uuid4().hex}.png"
+
+    img = Image.new("RGB", (Config.IMG_WIDTH, Config.IMG_HEIGHT), DEFAULT_BG_COLOR)
+    draw = ImageDraw.Draw(img)
+
+    try:
+        font_title = ImageFont.truetype(Config.POSTER_FONT_TITLE_PATH, 64)
+    except OSError:
+        font_title = ImageFont.load_default()
+    try:
+        font_text = ImageFont.truetype(Config.POSTER_FONT_TEXT_PATH, 32)
+    except OSError:
+        font_text = ImageFont.load_default()
+
+    bbox = draw.textbbox((0, 0), title, font=font_title)
+    x = (Config.IMG_WIDTH - (bbox[2] - bbox[0])) / 2
+    y = 60
+    draw.text((x, y), title, font=font_title, fill=TITLE_COLOR)
+
+    y += bbox[3] - bbox[1] + 40
+    for line in lines:
+        bbox = draw.textbbox((0, 0), line, font=font_text)
+        x = (Config.IMG_WIDTH - (bbox[2] - bbox[0])) / 2
+        draw.text((x, y), line, font=font_text, fill=TEXT_COLOR)
+        y += bbox[3] - bbox[1] + 10
+
+    img.save(file_path)
+    return str(file_path)


### PR DESCRIPTION
## Summary
- generate simple posters via `poster_generator`
- extend reminder autopilot with daily and weekly poster loops
- respect reminder opt-out list
- test DM poster attachments

## Testing
- `black utils/poster_generator.py bot/cogs/reminder_autopilot.py tests/test_reminder_timings.py`
- `isort utils/poster_generator.py bot/cogs/reminder_autopilot.py tests/test_reminder_timings.py`
- `flake8 utils/poster_generator.py bot/cogs/reminder_autopilot.py tests/test_reminder_timings.py`
- `pytest tests/test_reminder_timings.py -k daily_poster_attachment -q`

------
https://chatgpt.com/codex/tasks/task_e_685b32dd0554832481a426c97066fbb3