### PR TITLE
Add calendar config options

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,6 @@ R3_ROLE_IDS=111,222                     # Comma-separated R3 role IDs
 R4_ROLE_IDS=333,444                     # Comma-separated R4 role IDs
 ADMIN_ROLE_IDS=555,666                  # Comma-separated admin role IDs
 BASE_URL=http://localhost:8080          # Public base URL
+POSTER_OUTPUT_PATH=static/posters       # Directory for generated posters
+GOOGLE_CALENDAR_ID=                     # Optional Google calendar ID
+GOOGLE_SYNC_INTERVAL_MINUTES=30         # Sync interval in minutes

--- a/agents/scheduler_agent.py
+++ b/agents/scheduler_agent.py
@@ -8,6 +8,7 @@ import time
 import schedule
 
 from champion.autopilot import run_champion_autopilot
+from config import Config
 from utils.google_sync import sync_google_calendar
 
 
@@ -36,12 +37,13 @@ class SchedulerAgent:
         self.jobs.append(job)
         logging.info("\U0001f4c5 Champion Autopilot every %s hours scheduled", interval_hours)
 
-    def schedule_google_sync(self, interval_minutes: int = 30) -> None:
+    def schedule_google_sync(self, interval_minutes: int | None = None) -> None:
         """Schedule regular Google Calendar synchronization."""
 
-        job = schedule.every(interval_minutes).minutes.do(sync_google_calendar)
+        interval = interval_minutes or Config.GOOGLE_SYNC_INTERVAL_MINUTES
+        job = schedule.every(interval).minutes.do(sync_google_calendar)
         self.jobs.append(job)
         logging.info(
             "\U0001f4c5 Google Calendar sync every %s minutes scheduled",
-            interval_minutes,
+            interval,
         )

--- a/config.py
+++ b/config.py
@@ -54,6 +54,12 @@ class Config:
         filter(None, get_env_str("ADMIN_ROLE_IDS", default="").split(","))
     )
 
+    # --- Google Calendar ---
+    GOOGLE_CALENDAR_ID: str | None = get_env_str("GOOGLE_CALENDAR_ID", required=False)
+    GOOGLE_SYNC_INTERVAL_MINUTES: int = get_env_int(
+        "GOOGLE_SYNC_INTERVAL_MINUTES", required=False, default=30
+    )
+
     # --- i18n ---
     BABEL_DEFAULT_LOCALE = "de"
     BABEL_SUPPORTED_LOCALES = get_supported_languages()
@@ -78,6 +84,9 @@ class Config:
     ALLOWED_EXTENSIONS: set[str] = {"jpg", "png"}
     MAX_CONTENT_LENGTH: int = 2 * 1024 * 1024
 
+    POSTER_OUTPUT_PATH: str = get_env_str(
+        "POSTER_OUTPUT_PATH", default=os.path.join(STATIC_FOLDER, "posters")
+    )
     POSTER_OUTPUT_REL_PATH: str = "temp"
     MEDAL_OUTPUT_REL_PATH: str = "medals"
     CHAMPION_OUTPUT_REL_PATH: str = "champions"

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import asyncio
 
 import discord
 from discord.ext import commands
@@ -36,7 +35,9 @@ class DummyInteraction:
         self.response = DummyResponse()
         self.followup = DummyFollowup()
 
+
 def run(coro):
+    """Execute coroutine synchronously for tests."""
     try:
         loop = asyncio.get_event_loop()
     except RuntimeError:
@@ -44,13 +45,6 @@ def run(coro):
         asyncio.set_event_loop(loop)
     return loop.run_until_complete(coro)
 
-    """Execute coroutine synchronously for tests."""
-    return asyncio.run(coro)
-    loop = asyncio.new_event_loop()
-    try:
-        return loop.run_until_complete(coro)
-    finally:
-        loop.close()
 
 def test_missing_permissions_message():
     bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())

--- a/tests/test_google_sync.py
+++ b/tests/test_google_sync.py
@@ -50,7 +50,7 @@ def test_sync_google_calendar(monkeypatch):
     monkeypatch.setattr(mod, "get_service", lambda: object())
     monkeypatch.setattr(mod, "fetch_calendar_events", fake_fetch)
     monkeypatch.setattr(mod, "import_events", fake_import)
-    monkeypatch.setenv("GOOGLE_CALENDAR_ID", "test")
+    monkeypatch.setattr(mod.Config, "GOOGLE_CALENDAR_ID", "test")
 
     mod.sync_google_calendar()
     assert called["calendar_id"] == "test"

--- a/tests/test_nav_rendering.py
+++ b/tests/test_nav_rendering.py
@@ -1,6 +1,3 @@
-import pytest
-
-
 def login_role(client, role: str) -> None:
     with client.session_transaction() as sess:
         sess["user"] = {"role_level": role}

--- a/tests/test_public_flows.py
+++ b/tests/test_public_flows.py
@@ -1,5 +1,6 @@
 import importlib
 import json
+from pathlib import Path
 
 import requests
 
@@ -117,8 +118,8 @@ def test_post_reminder(client):
 def test_get_poster_image(client, tmp_path, monkeypatch):
     from config import Config
 
-    monkeypatch.setattr(Config, "STATIC_FOLDER", str(tmp_path))
-    posters = tmp_path / "posters"
+    monkeypatch.setattr(Config, "POSTER_OUTPUT_PATH", str(tmp_path / "posters"))
+    posters = Path(Config.POSTER_OUTPUT_PATH)
     posters.mkdir()
     file = posters / "example.png"
     file.write_bytes(b"\x89PNG\r\n\x1a\n")

--- a/tests/test_resources_blueprint.py
+++ b/tests/test_resources_blueprint.py
@@ -1,5 +1,3 @@
-from io import BytesIO
-
 from tests.test_admin_auth import login_with_role
 
 

--- a/utils/google_sync.py
+++ b/utils/google_sync.py
@@ -11,6 +11,7 @@ from typing import Iterable
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
 
+from config import Config
 from mongo_service import get_collection
 
 log = logging.getLogger(__name__)
@@ -84,7 +85,7 @@ def import_events(events: Iterable[dict]) -> None:
 
 def sync_google_calendar() -> None:
     """Synchronize events from Google Calendar into MongoDB."""
-    calendar_id = os.getenv("GOOGLE_CALENDAR_ID")
+    calendar_id = Config.GOOGLE_CALENDAR_ID
     if not calendar_id:
         log.warning("GOOGLE_CALENDAR_ID not set – skipping Google sync")
         return

--- a/web/poster_routes.py
+++ b/web/poster_routes.py
@@ -11,7 +11,7 @@ poster_blueprint = Blueprint("poster", __name__)
 
 
 def _poster_dir() -> Path:
-    path = Path(Config.STATIC_FOLDER) / "posters"
+    path = Path(Config.POSTER_OUTPUT_PATH)
     path.mkdir(parents=True, exist_ok=True)
     return path
 


### PR DESCRIPTION
## Summary
- add `GOOGLE_CALENDAR_ID`, `POSTER_OUTPUT_PATH` and `GOOGLE_SYNC_INTERVAL_MINUTES` to `Config`
- use these values in Google sync, scheduler and poster routes
- document the new environment variables
- adjust tests for updated settings

## Testing
- `flake8`
- `pytest -q` *(fails: test_command_translator.py, test_leaderboard_cog.py, test_newsletter_autopilot.py, test_reminder_timings.py, test_translations_valid.py)*

------
https://chatgpt.com/codex/tasks/task_e_685b32dc9cbc83249245227934150efd