### PR TITLE
Add async google calendar sync task

### DIFF
--- a/agents/scheduler_agent.py
+++ b/agents/scheduler_agent.py
@@ -8,7 +8,7 @@ import time
 import schedule
 
 from champion.autopilot import run_champion_autopilot
-from utils.google_sync import sync_google_calendar
+from utils.google_sync_task import start_google_sync
 
 
 class SchedulerAgent:
@@ -38,10 +38,8 @@ class SchedulerAgent:
 
     def schedule_google_sync(self, interval_minutes: int = 30) -> None:
         """Schedule regular Google Calendar synchronization."""
-
-        job = schedule.every(interval_minutes).minutes.do(sync_google_calendar)
-        self.jobs.append(job)
+        start_google_sync(interval_minutes)
         logging.info(
-            "\U0001f4c5 Google Calendar sync every %s minutes scheduled",
+            "\U0001f4c5 Google Calendar sync every %s minutes scheduled via loop",
             interval_minutes,
         )

--- a/tests/test_command_translator.py
+++ b/tests/test_command_translator.py
@@ -4,10 +4,12 @@ import discord
 from discord import app_commands
 
 from bot.translator import MyTranslator
+from fur_lang import i18n
 
 
 def test_translator_command_name():
     translator = MyTranslator()
+    i18n.translations = {"en": {"cmd_ping_name": "ping"}, "de": {"cmd_ping_name": "ping"}}
     ctx = app_commands.TranslationContext(
         location=app_commands.TranslationContextLocation.command_name,
         data=None,

--- a/tests/test_google_sync_task.py
+++ b/tests/test_google_sync_task.py
@@ -1,0 +1,27 @@
+import asyncio
+import sys
+import types
+
+
+def test_google_sync_task_runs(monkeypatch):
+    sys.modules.setdefault("schedule", types.ModuleType("schedule"))
+
+    import agents.scheduler_agent as agent_mod
+    import utils.google_sync_task as task_mod
+
+    called = {"count": 0}
+
+    def fake_sync():
+        called["count"] += 1
+
+    monkeypatch.setattr(task_mod, "sync_google_calendar", fake_sync)
+
+    def fake_start():
+        asyncio.run(task_mod.google_sync_loop.coro())
+
+    monkeypatch.setattr(task_mod.google_sync_loop, "start", fake_start)
+
+    agent = agent_mod.SchedulerAgent()
+    agent.schedule_google_sync(interval_minutes=1)
+
+    assert called["count"] == 1

--- a/tests/test_leaderboard_cog.py
+++ b/tests/test_leaderboard_cog.py
@@ -2,6 +2,7 @@ import asyncio
 import types
 
 import bot.cogs.leaderboard as lb_mod
+from fur_lang import i18n
 
 
 class DummyCollection:
@@ -43,6 +44,20 @@ class DummyInteraction:
 
 
 def test_leaderboard_cache(monkeypatch):
+    i18n.translations = {
+        "en": {
+            "leaderboard_message": "{header}\n{content}",
+            "leaderboard_header": "LB",
+            "leaderboard_unknown_category": "bad",
+            "leaderboard_error": "err",
+        },
+        "de": {
+            "leaderboard_message": "{header}\n{content}",
+            "leaderboard_header": "LB",
+            "leaderboard_unknown_category": "bad",
+            "leaderboard_error": "err",
+        },
+    }
     dummy = DummyCollection()
     monkeypatch.setattr(
         lb_mod, "get_collection", lambda name: dummy if name == "leaderboard" else DummyUsers()
@@ -66,6 +81,20 @@ def test_leaderboard_cache(monkeypatch):
 
 
 def test_cog_unload_cancels(monkeypatch):
+    i18n.translations = {
+        "en": {
+            "leaderboard_message": "{header}\n{content}",
+            "leaderboard_header": "LB",
+            "leaderboard_unknown_category": "bad",
+            "leaderboard_error": "err",
+        },
+        "de": {
+            "leaderboard_message": "{header}\n{content}",
+            "leaderboard_header": "LB",
+            "leaderboard_unknown_category": "bad",
+            "leaderboard_error": "err",
+        },
+    }
     bot = types.SimpleNamespace()
 
     monkeypatch.setattr(lb_mod.tasks.Loop, "start", lambda self, *a, **k: None)

--- a/tests/test_newsletter_autopilot.py
+++ b/tests/test_newsletter_autopilot.py
@@ -2,8 +2,6 @@ import asyncio
 from datetime import datetime
 from types import SimpleNamespace
 
-import pytest
-
 import bot.cogs.newsletter_autopilot as mod
 
 
@@ -82,8 +80,7 @@ def test_should_send_daily_overview():
     assert not mod.should_send_daily_overview(later)
 
 
-@pytest.mark.asyncio
-async def test_daily_opt_out(monkeypatch):
+def test_daily_opt_out(monkeypatch):
     guild = FakeGuild(members=[FakeMember(id=1), FakeMember(id=2)])
     bot = FakeBot(guild=guild)
 
@@ -97,7 +94,7 @@ async def test_daily_opt_out(monkeypatch):
     monkeypatch.setattr(mod.Config, "DISCORD_GUILD_ID", 1)
 
     cog = mod.NewsletterAutopilot(bot)
-    await cog.send_daily_overview()
+    asyncio.run(cog.send_daily_overview())
 
     assert cog.blocked == 2
     assert cog.sent == 0

--- a/translations/de.json
+++ b/translations/de.json
@@ -79,7 +79,7 @@
     "No resources available.": "Keine Ressourcen verfügbar.",
     "Resources": "Ressourcen",
     "Resource Downloads": "Ressourcen",
-    "example_desc": "Beispieldatei"
+    "example_desc": "Beispieldatei",
     "Keine Dateien verfügbar.": "Keine Dateien verfügbar.",
     "Keine Einträge": "Keine Einträge",
     "Keine Einträge in dieser Kategorie.": "Keine Einträge in dieser Kategorie.",

--- a/translations/en.json
+++ b/translations/en.json
@@ -79,7 +79,7 @@
     "No resources available.": "No resources available.",
     "Resources": "Resources",
     "Resource Downloads": "Resource Downloads",
-    "example_desc": "Example resource file"
+    "example_desc": "Example resource file",
     "Keine Dateien verfügbar.": "Keine Dateien verfügbar.",
     "Keine Einträge": "No entries",
     "Keine Einträge in dieser Kategorie.": "Keine Einträge in dieser Kategorie.",

--- a/utils/google_sync_task.py
+++ b/utils/google_sync_task.py
@@ -1,0 +1,33 @@
+"""Background task to sync Google Calendar periodically."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+from discord.ext import tasks
+
+from utils.google_sync import sync_google_calendar
+
+log = logging.getLogger(__name__)
+
+DEFAULT_INTERVAL_MINUTES = int(os.getenv("GOOGLE_SYNC_INTERVAL_MINUTES", "30"))
+
+
+@tasks.loop(minutes=DEFAULT_INTERVAL_MINUTES)
+async def google_sync_loop() -> None:
+    """Run ``sync_google_calendar`` in a thread."""
+    await asyncio.to_thread(sync_google_calendar)
+
+
+def start_google_sync(interval_minutes: int | None = None) -> None:
+    """Start the background sync loop with the given interval."""
+    minutes = interval_minutes or DEFAULT_INTERVAL_MINUTES
+    if google_sync_loop.is_running():
+        google_sync_loop.change_interval(minutes=minutes)
+    else:
+        if minutes != DEFAULT_INTERVAL_MINUTES:
+            google_sync_loop.change_interval(minutes=minutes)
+        google_sync_loop.start()
+    log.info("Google sync loop started (%s min)", minutes)


### PR DESCRIPTION
## Summary
- add `google_sync_task` for background calendar sync
- register loop in `SchedulerAgent.schedule_google_sync`
- update unit tests for translations and loops
- ensure translation JSON files are valid

## Testing
- `black . && isort . && flake8`
- `pytest --disable-warnings --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_685b32db419083249170e1cbe294a578