### PR TITLE
Fix scheduler_agent logging close parenthesis

### DIFF
--- a/agents/scheduler_agent.py
+++ b/agents/scheduler_agent.py
@@ -8,9 +8,9 @@ import time
 import schedule
 
 from champion.autopilot import run_champion_autopilot
-from utils.google_sync_task import start_google_sync
 from config import Config
 from utils.google_sync import sync_google_calendar
+from utils.google_sync_task import start_google_sync
 
 
 class SchedulerAgent:
@@ -44,6 +44,7 @@ class SchedulerAgent:
         logging.info(
             "\U0001f4c5 Google Calendar sync every %s minutes scheduled via loop",
             interval_minutes,
+        )
 
         interval = interval_minutes or Config.GOOGLE_SYNC_INTERVAL_MINUTES
         job = schedule.every(interval).minutes.do(sync_google_calendar)


### PR DESCRIPTION
## Summary
- close `logging.info` call in `schedule_google_sync`
- adjust import order via isort

## Testing
- `python -m py_compile agents/scheduler_agent.py`
- `flake8` *(fails: poster generator unused variable)*
- `pytest --maxfail=1 -q` *(fails: AttributeError in schedule stub)*

------
https://chatgpt.com/codex/tasks/task_e_685b5bfdfebc8324812b5d623b66abb4