### PR TITLE
Add Google OAuth integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,6 @@ BASE_URL=http://localhost:8080          # Public base URL
 POSTER_OUTPUT_PATH=static/posters       # Directory for generated posters
 GOOGLE_CALENDAR_ID=                     # Optional Google calendar ID
 GOOGLE_SYNC_INTERVAL_MINUTES=30         # Sync interval in minutes
+GOOGLE_REDIRECT_URI=http://localhost:8080/oauth2callback  # OAuth redirect URL
+GOOGLE_CREDENTIALS_FILE=google_credentials.json           # Token store path
+GOOGLE_CALENDAR_SCOPES=https://www.googleapis.com/auth/calendar.readonly

--- a/config.py
+++ b/config.py
@@ -59,6 +59,12 @@ class Config:
     GOOGLE_SYNC_INTERVAL_MINUTES: int = get_env_int(
         "GOOGLE_SYNC_INTERVAL_MINUTES", required=False, default=30
     )
+    GOOGLE_REDIRECT_URI: str | None = get_env_str("GOOGLE_REDIRECT_URI", required=False)
+    GOOGLE_CREDENTIALS_FILE: str | None = get_env_str("GOOGLE_CREDENTIALS_FILE", required=False)
+    GOOGLE_CALENDAR_SCOPES: list[str] = get_env_str(
+        "GOOGLE_CALENDAR_SCOPES",
+        default="https://www.googleapis.com/auth/calendar.readonly",
+    ).split(",")
 
     # --- i18n ---
     BABEL_DEFAULT_LOCALE = "de"

--- a/google_auth.py
+++ b/google_auth.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Optional
+
+from flask import Blueprint, current_app, redirect, request, session, url_for
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import Flow
+
+google_auth = Blueprint("google_auth", __name__)
+
+
+def _cred_path() -> Optional[str]:
+    return current_app.config.get("GOOGLE_CREDENTIALS_FILE")
+
+
+def _save_credentials(creds: Credentials) -> None:
+    path = _cred_path()
+    if not path:
+        return
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(creds.to_json())
+
+
+def load_credentials() -> Optional[Credentials]:
+    """Load stored credentials and refresh if expired."""
+    path = _cred_path()
+    if not path or not os.path.exists(path):
+        return None
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    scopes = current_app.config.get(
+        "GOOGLE_CALENDAR_SCOPES",
+        ["https://www.googleapis.com/auth/calendar.readonly"],
+    )
+    creds = Credentials.from_authorized_user_info(data, scopes)
+    if creds and creds.expired and creds.refresh_token:
+        creds.refresh(Request())
+        _save_credentials(creds)
+    return creds
+
+
+@google_auth.route("/auth/google")
+def auth_google():
+    path = _cred_path()
+    if not path or not os.path.exists(path):
+        return "Missing Google client config", 500
+    with open(path, "r", encoding="utf-8") as fh:
+        config = json.load(fh)
+    flow = Flow.from_client_config(
+        config,
+        scopes=current_app.config.get(
+            "GOOGLE_CALENDAR_SCOPES",
+            ["https://www.googleapis.com/auth/calendar.readonly"],
+        ),
+        redirect_uri=current_app.config.get("GOOGLE_REDIRECT_URI"),
+    )
+    authorization_url, state = flow.authorization_url(
+        access_type="offline",
+        include_granted_scopes="true",
+        prompt="consent",
+    )
+    session["google_oauth_state"] = state
+    return redirect(authorization_url)
+
+
+@google_auth.route("/oauth2callback")
+def oauth2callback():
+    state = session.pop("google_oauth_state", None)
+    path = _cred_path()
+    if not path or not os.path.exists(path):
+        return "Missing Google client config", 500
+    with open(path, "r", encoding="utf-8") as fh:
+        config = json.load(fh)
+    flow = Flow.from_client_config(
+        config,
+        scopes=current_app.config.get(
+            "GOOGLE_CALENDAR_SCOPES",
+            ["https://www.googleapis.com/auth/calendar.readonly"],
+        ),
+        state=state,
+        redirect_uri=current_app.config.get("GOOGLE_REDIRECT_URI"),
+    )
+    flow.fetch_token(authorization_response=request.url)
+    creds = flow.credentials
+    _save_credentials(creds)
+    return redirect(url_for("public.dashboard"))
+
+
+__all__ = ["google_auth", "load_credentials"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,15 @@ os.environ.setdefault("R3_ROLE_IDS", "1")
 os.environ.setdefault("R4_ROLE_IDS", "1")
 os.environ.setdefault("ADMIN_ROLE_IDS", "1")
 os.environ.setdefault("BASE_URL", "http://localhost:8080")
+os.environ.setdefault(
+    "GOOGLE_REDIRECT_URI",
+    "http://localhost:8080/oauth2callback",
+)
+os.environ.setdefault("GOOGLE_CREDENTIALS_FILE", "/tmp/google.json")
+os.environ.setdefault(
+    "GOOGLE_CALENDAR_SCOPES",
+    "https://www.googleapis.com/auth/calendar.readonly",
+)
 
 try:
     asyncio.get_event_loop()

--- a/tests/test_google_auth.py
+++ b/tests/test_google_auth.py
@@ -1,0 +1,73 @@
+import json
+
+import google_auth as mod
+
+
+def test_google_login_flow(client, tmp_path, monkeypatch):
+    config = {
+        "web": {
+            "client_id": "id",
+            "client_secret": "secret",
+            "auth_uri": "https://auth",
+            "token_uri": "https://token",
+        }
+    }
+    cfg_file = tmp_path / "google.json"
+    cfg_file.write_text(json.dumps(config))
+    client.application.config.update(
+        GOOGLE_CREDENTIALS_FILE=str(cfg_file),
+        GOOGLE_REDIRECT_URI="http://localhost:8080/oauth2callback",
+        GOOGLE_CALENDAR_SCOPES=["scope"],
+    )
+
+    class FakeFlow:
+        def authorization_url(self, **kwargs):
+            return "http://consent", "state1"
+
+    monkeypatch.setattr(
+        mod.Flow,
+        "from_client_config",
+        lambda cfg, scopes, redirect_uri=None, state=None: FakeFlow(),
+    )
+
+    resp = client.get("/auth/google")
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == "http://consent"
+    with client.session_transaction() as sess:
+        assert sess["google_oauth_state"] == "state1"
+
+
+def test_load_credentials_refresh(monkeypatch, tmp_path, app):
+    path = tmp_path / "token.json"
+    app.config.update(GOOGLE_CREDENTIALS_FILE=str(path), GOOGLE_CALENDAR_SCOPES=["scope"])
+    data = {
+        "token": "old",
+        "refresh_token": "r",
+        "client_id": "id",
+        "client_secret": "secret",
+        "token_uri": "https://token",
+    }
+    path.write_text(json.dumps(data))
+
+    refreshed = {}
+
+    class FakeCred:
+        expired = True
+        refresh_token = "r"
+
+        def refresh(self, request):
+            refreshed["called"] = True
+
+        def to_json(self):
+            data["token"] = "new"
+            return json.dumps(data)
+
+    monkeypatch.setattr(
+        mod.Credentials, "from_authorized_user_info", lambda info, scopes: FakeCred()
+    )
+    monkeypatch.setattr(mod, "Request", lambda: object())
+
+    cred = mod.load_credentials()
+    assert isinstance(cred, FakeCred)
+    assert refreshed["called"]
+    assert json.loads(path.read_text())["token"] == "new"

--- a/utils/google_sync.py
+++ b/utils/google_sync.py
@@ -2,30 +2,25 @@
 
 from __future__ import annotations
 
-import json
 import logging
-import os
 from datetime import datetime
 from typing import Iterable
 
-from google.oauth2 import service_account
 from googleapiclient.discovery import build
 
 from config import Config
+from google_auth import load_credentials
 from mongo_service import get_collection
 
 log = logging.getLogger(__name__)
-SCOPES = ["https://www.googleapis.com/auth/calendar.readonly"]
 
 
 def get_service():
     """Return a Calendar API service or ``None`` if credentials are missing."""
-    creds_json = os.getenv("GOOGLE_CREDENTIALS_JSON")
-    if not creds_json:
-        log.warning("GOOGLE_CREDENTIALS_JSON not set – skipping Google sync")
+    creds = load_credentials()
+    if not creds:
+        log.warning("Google OAuth credentials missing – skipping Google sync")
         return None
-    info = json.loads(creds_json)
-    creds = service_account.Credentials.from_service_account_info(info, scopes=SCOPES)
     return build("calendar", "v3", credentials=creds, cache_discovery=False)
 
 

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -121,6 +121,9 @@ def create_app() -> Flask:
         if reminder_api:
             app.register_blueprint(reminder_api, url_prefix="/api/reminders")
         app.register_blueprint(dashboard)
+        from google_auth import google_auth as google_auth_bp
+
+        app.register_blueprint(google_auth_bp)
 
         # API-Blueprints
         app.register_blueprint(api_events)


### PR DESCRIPTION
## Summary
- introduce `google_auth` blueprint for OAuth login & token storage
- use refreshed credentials in `google_sync`
- expose new Google config options
- wire up blueprint in app factory
- document new env variables
- include tests for login and token refresh logic

## Testing
- `black google_auth.py utils/google_sync.py config.py tests/test_google_auth.py tests/conftest.py web/__init__.py`
- `isort google_auth.py utils/google_sync.py config.py tests/test_google_auth.py tests/conftest.py web/__init__.py`
- `flake8 google_auth.py utils/google_sync.py config.py tests/test_google_auth.py tests/conftest.py web/__init__.py`
- `pytest tests/test_google_auth.py` *(fails: ModuleNotFoundError: No module named 'pymongo')*

------
https://chatgpt.com/codex/tasks/task_e_685b5bff96348324b2c3f6f554e527b3