### PR TITLE
Fix reminder participant lookup

### DIFF
--- a/agents/scheduler_agent.py
+++ b/agents/scheduler_agent.py
@@ -8,9 +8,9 @@ import time
 import schedule
 
 from champion.autopilot import run_champion_autopilot
-from utils.google_sync_task import start_google_sync
 from config import Config
 from utils.google_sync import sync_google_calendar
+from utils.google_sync_task import start_google_sync
 
 
 class SchedulerAgent:
@@ -44,11 +44,13 @@ class SchedulerAgent:
         logging.info(
             "\U0001f4c5 Google Calendar sync every %s minutes scheduled via loop",
             interval_minutes,
+        )
 
         interval = interval_minutes or Config.GOOGLE_SYNC_INTERVAL_MINUTES
-        job = schedule.every(interval).minutes.do(sync_google_calendar)
-        self.jobs.append(job)
-        logging.info(
-            "\U0001f4c5 Google Calendar sync every %s minutes scheduled",
-            interval,
-        )
+        if hasattr(schedule, "every"):
+            job = schedule.every(interval).minutes.do(sync_google_calendar)
+            self.jobs.append(job)
+            logging.info(
+                "\U0001f4c5 Google Calendar sync every %s minutes scheduled",
+                interval,
+            )

--- a/bot/cogs/reminder_cog.py
+++ b/bot/cogs/reminder_cog.py
@@ -60,7 +60,7 @@ class ReminderCog(commands.Cog):
                 )
             ]
             for event in events:
-                participants = get_collection("participants").find({"event_id": event["_id"]})
+                participants = get_collection("event_participants").find({"event_id": event["_id"]})
                 for p in participants:
                     user_id = int(p["user_id"])
                     if get_collection("reminders_sent").find_one(

--- a/tests/test_poster_generator.py
+++ b/tests/test_poster_generator.py
@@ -2,7 +2,7 @@ import os
 from datetime import datetime
 
 from config import Config
-from utils.poster_generator import generate_poster
+from utils.poster_generator import generate_event_poster
 
 
 def test_generate_poster_daily_weekly(monkeypatch, tmp_path):
@@ -10,8 +10,8 @@ def test_generate_poster_daily_weekly(monkeypatch, tmp_path):
     monkeypatch.setattr(Config, "POSTER_OUTPUT_REL_PATH", "")
 
     event = {"title": "Test", "event_time": datetime(2025, 1, 1, 12, 0)}
-    path_daily = generate_poster(event, "daily")
+    path_daily = generate_event_poster(event, "daily")
     assert os.path.isfile(path_daily)
 
-    path_weekly = generate_poster(event, "weekly")
+    path_weekly = generate_event_poster(event, "weekly")
     assert os.path.isfile(path_weekly)

--- a/tests/test_reminder_timings.py
+++ b/tests/test_reminder_timings.py
@@ -102,7 +102,7 @@ def test_reminder_cog_sends_60min(monkeypatch):
     def get_coll(name):
         return {
             "events": events_col,
-            "participants": participants_col,
+            "event_participants": participants_col,
             "reminders_sent": sent_col,
             "reminder_optout": optout_col,
             "user_settings": user_settings_col,

--- a/utils/poster_generator.py
+++ b/utils/poster_generator.py
@@ -46,6 +46,9 @@ def generate_poster(title: str, lines: list[str], output_dir: str | None = None)
         draw.text((x, y), line, font=font_text, fill=TEXT_COLOR)
         y += bbox[3] - bbox[1] + 10
 
+    img.save(file_path)
+    return str(file_path)
+
 
 # Background images for each mode (using default static directory)
 MODE_BACKGROUNDS = {
@@ -62,7 +65,7 @@ def _load_font(path: str, size: int) -> ImageFont.FreeTypeFont | ImageFont.Image
         return ImageFont.load_default()
 
 
-def generate_poster(event: dict, mode: str = "daily") -> str:
+def generate_event_poster(event: dict, mode: str = "daily") -> str:
     """Generate a poster image for an event.
 
     Parameters


### PR DESCRIPTION
## Summary
- update reminder cog to use `event_participants` collection
- fix scheduler task to ignore missing `schedule.every`
- ensure poster generator functions don't conflict
- adjust tests for updated collections and poster generator name

## Testing
- `isort . && black . && flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b5bfe654c8324b6ab460cbef96ebf