### PR TITLE
Refactor poster generator API

### DIFF
--- a/agents/scheduler_agent.py
+++ b/agents/scheduler_agent.py
@@ -8,9 +8,9 @@ import time
 import schedule
 
 from champion.autopilot import run_champion_autopilot
-from utils.google_sync_task import start_google_sync
 from config import Config
 from utils.google_sync import sync_google_calendar
+from utils.google_sync_task import start_google_sync
 
 
 class SchedulerAgent:
@@ -44,11 +44,13 @@ class SchedulerAgent:
         logging.info(
             "\U0001f4c5 Google Calendar sync every %s minutes scheduled via loop",
             interval_minutes,
+        )
 
         interval = interval_minutes or Config.GOOGLE_SYNC_INTERVAL_MINUTES
-        job = schedule.every(interval).minutes.do(sync_google_calendar)
-        self.jobs.append(job)
-        logging.info(
-            "\U0001f4c5 Google Calendar sync every %s minutes scheduled",
-            interval,
-        )
+        if hasattr(schedule, "every"):
+            job = schedule.every(interval).minutes.do(sync_google_calendar)
+            self.jobs.append(job)
+            logging.info(
+                "\U0001f4c5 Google Calendar sync every %s minutes scheduled",
+                interval,
+            )

--- a/bot/cogs/reminder_autopilot.py
+++ b/bot/cogs/reminder_autopilot.py
@@ -187,12 +187,12 @@ class ReminderAutopilot(commands.Cog):
 
     async def send_daily_poster(self) -> None:
         lines = await self._build_daily_lines()
-        path = poster_generator.generate_poster("Today's Events", lines)
+        path = poster_generator.generate_text_poster("Today's Events", lines)
         await self._send_poster_to_members(path)
 
     async def send_weekly_poster(self) -> None:
         lines = await self._build_weekly_lines()
-        path = poster_generator.generate_poster("Events This Week", lines)
+        path = poster_generator.generate_text_poster("Events This Week", lines)
         await self._send_poster_to_members(path)
 
     @tasks.loop(hours=1)

--- a/tests/test_reminder_timings.py
+++ b/tests/test_reminder_timings.py
@@ -153,7 +153,7 @@ async def test_daily_poster_attachment(monkeypatch, tmp_path):
     monkeypatch.setattr(autopilot_mod, "is_opted_out", lambda uid: False)
     monkeypatch.setattr(
         autopilot_mod.poster_generator,
-        "generate_poster",
+        "generate_text_poster",
         lambda *a, **k: str(poster_file),
     )
     monkeypatch.setattr(autopilot_mod.discord, "File", lambda p: {"path": p})

--- a/utils/poster_generator.py
+++ b/utils/poster_generator.py
@@ -15,8 +15,8 @@ TITLE_COLOR = Config.CHAMPION_TEXT_COLOR
 TEXT_COLOR = Config.CHAMPION_SUBTEXT_COLOR
 
 
-def generate_poster(title: str, lines: list[str], output_dir: str | None = None) -> str:
-    """Create a simple poster image with a title and lines of text."""
+def generate_text_poster(title: str, lines: list[str], output_dir: str | None = None) -> str:
+    """Create a simple poster image with a title and multiple lines of text."""
     out_dir = Path(output_dir or Config.STATIC_FOLDER) / Config.POSTER_OUTPUT_REL_PATH
     out_dir.mkdir(parents=True, exist_ok=True)
 
@@ -45,6 +45,9 @@ def generate_poster(title: str, lines: list[str], output_dir: str | None = None)
         x = (Config.IMG_WIDTH - (bbox[2] - bbox[0])) / 2
         draw.text((x, y), line, font=font_text, fill=TEXT_COLOR)
         y += bbox[3] - bbox[1] + 10
+
+    img.save(file_path)
+    return str(file_path)
 
 
 # Background images for each mode (using default static directory)


### PR DESCRIPTION
## Summary
- rename helper to `generate_text_poster`
- update ReminderAutopilot usage
- avoid crashing SchedulerAgent when `schedule.every` is missing
- adjust reminder timing test

## Testing
- `isort agents/scheduler_agent.py bot/cogs/reminder_autopilot.py utils/poster_generator.py tests/test_reminder_timings.py`
- `black agents/scheduler_agent.py bot/cogs/reminder_autopilot.py utils/poster_generator.py tests/test_reminder_timings.py`
- `flake8`
- `pytest -vv`

------
https://chatgpt.com/codex/tasks/task_e_685b5bfe3f7c83249fe67f544317c8d5