### PR TITLE
🧹 Cleanup unused flags

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -25,6 +25,7 @@ Several helper scripts live in `i18n_tools/` to keep the JSON files in sync:
   using online translation services
 - `translate_sync.py` – synchronize and report missing phrases for many
   languages
+- `cleanup_flags.py` – remove flag icons without matching translations
 
 Run these scripts from the project root as needed to update the translation
 files. After updating, commit the modified JSON files to version control.

--- a/i18n_tools/__init__.py
+++ b/i18n_tools/__init__.py
@@ -1,0 +1,3 @@
+from .cleanup_flags import cleanup_flags
+
+__all__ = ["cleanup_flags"]

--- a/i18n_tools/cleanup_flags.py
+++ b/i18n_tools/cleanup_flags.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+from typing import List
+
+
+def cleanup_flags(
+    flag_dir: str | Path = "static/flags",
+    translations_dir: str | Path = "translations",
+) -> List[str]:
+    """Delete flag PNG files without matching translation JSON.
+
+    Args:
+        flag_dir: Directory containing ``*.png`` flag images.
+        translations_dir: Directory containing ``*.json`` translations.
+
+    Returns:
+        List of removed flag file names.
+    """
+    flag_path = Path(flag_dir)
+    translations_path = Path(translations_dir)
+    removed: List[str] = []
+    for flag_file in flag_path.glob("*.png"):
+        lang_code = flag_file.stem
+        if not (translations_path / f"{lang_code}.json").exists():
+            flag_file.unlink()
+            removed.append(flag_file.name)
+    return removed
+
+
+if __name__ == "__main__":
+    removed = cleanup_flags()
+    if removed:
+        print(f"🧹 Removed {len(removed)} unused flags: {', '.join(removed)}")
+    else:
+        print("✅ No unused flag icons found.")

--- a/tests/test_flag_translation_check.py
+++ b/tests/test_flag_translation_check.py
@@ -22,3 +22,24 @@ def test_warns_when_flag_missing_translation(tmp_path, caplog):
     assert any(
         "Flag 'xx.png' found but no xx.json translation." in r.message for r in caplog.records
     )
+
+
+def test_cleanup_flags_removes_unused(tmp_path):
+    flags_dir = tmp_path / "static" / "flags"
+    flags_dir.mkdir(parents=True)
+    unused = flags_dir / "xx.png"
+    unused.write_bytes(b"img")
+    used = flags_dir / "de.png"
+    used.write_bytes(b"img")
+
+    translations_dir = tmp_path / "translations"
+    translations_dir.mkdir()
+    (translations_dir / "de.json").write_text("{}")
+
+    from i18n_tools.cleanup_flags import cleanup_flags
+
+    removed = cleanup_flags(flags_dir, translations_dir)
+
+    assert unused.name in removed
+    assert not unused.exists()
+    assert used.exists()


### PR DESCRIPTION
## Summary
- add cleanup_flags.py for removing flag icons without matching translations
- export cleanup_flags in i18n_tools
- document cleanup_flags script
- test removal of unused flags

## Testing
- `black i18n_tools/cleanup_flags.py i18n_tools/__init__.py tests/test_flag_translation_check.py`
- `isort i18n_tools/cleanup_flags.py i18n_tools/__init__.py tests/test_flag_translation_check.py`
- `flake8 .`
- `pytest --disable-warnings --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_685b60a722648324aacd76a2bd59c6ce