### PR TITLE
Add dedicated event channel support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ DISCORD_WEBHOOK_URL=                    # Optional Discord webhook
 DISCORD_TOKEN=your-discord-bot-token    # Discord bot token
 DISCORD_GUILD_ID=1234567890             # Discord server ID
 REMINDER_CHANNEL_ID=1234567890          # Channel ID for reminders
+DISCORD_EVENT_CHANNEL_ID=1234567890     # Optional channel ID for events
 DISCORD_CLIENT_ID=your-client-id        # OAuth client ID
 DISCORD_CLIENT_SECRET=your-client-secret  # OAuth client secret
 DISCORD_REDIRECT_URI=https://example.com/discord/callback  # OAuth redirect URL

--- a/agents/webhook_agent.py
+++ b/agents/webhook_agent.py
@@ -5,6 +5,9 @@ from typing import Optional
 
 import requests
 
+from config import Config
+from utils.discord_util import send_discord_message
+
 
 class WebhookAgent:
     def __init__(self, default_url: Optional[str] = None):
@@ -15,7 +18,34 @@ class WebhookAgent:
         content: str,
         webhook_url: Optional[str] = None,
         file_path: Optional[str] = None,
+        *,
+        event_channel: bool = False,
     ) -> bool:
+        """Send a Discord webhook or channel message.
+
+        Parameters
+        ----------
+        content:
+            Message text to send.
+        webhook_url:
+            Override webhook URL. If ``event_channel`` is ``True`` this is
+            ignored.
+        file_path:
+            Optional path to an attachment.
+        event_channel:
+            If ``True`` and ``Config.DISCORD_EVENT_CHANNEL_ID`` is set, the
+            message is posted via ``send_discord_message``.
+        """
+
+        if event_channel and Config.DISCORD_EVENT_CHANNEL_ID:
+            try:
+                send_discord_message(Config.DISCORD_EVENT_CHANNEL_ID, content, file_path)
+                logging.info("📤 Event-Channel Nachricht gesendet")
+                return True
+            except Exception as e:  # pragma: no cover - network failure
+                logging.error(f"❌ Fehler beim Channel-Senden: {e}")
+                return False
+
         url = webhook_url or self.default_url
         if not url:
             logging.error("❌ Kein Webhook-URL angegeben")

--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -21,6 +21,7 @@ from agents.webhook_agent import WebhookAgent
 from config import Config
 from mongo_service import db
 from utils.discord_util import require_roles
+from utils.poster_generator import generate_event_poster
 from web.auth.decorators import r4_required
 
 admin = Blueprint("admin", __name__)
@@ -291,7 +292,8 @@ def post_event(event_id: str):
         f"📅 **{event.get('title')}**\n{event.get('description', '')}\n🕒 {event.get('event_date')}"
     )
     webhook = WebhookAgent(Config.DISCORD_WEBHOOK_URL)
-    success = webhook.send(content)
+    poster = generate_event_poster(event)
+    success = webhook.send(content, file_path=poster, event_channel=True)
     if success:
         flash("Event gepostet", "success")
     else:

--- a/config.py
+++ b/config.py
@@ -43,6 +43,7 @@ class Config:
     DISCORD_TOKEN: str = get_env_str("DISCORD_TOKEN", required=True)
     DISCORD_GUILD_ID: int = get_env_int("DISCORD_GUILD_ID", required=True)
     REMINDER_CHANNEL_ID: int = get_env_int("REMINDER_CHANNEL_ID", required=True)
+    DISCORD_EVENT_CHANNEL_ID: int | None = get_env_int("DISCORD_EVENT_CHANNEL_ID", required=False)
     REMINDER_ROLE_ID: int | None = get_env_int("REMINDER_ROLE_ID", required=False)
     DISCORD_CLIENT_ID: str = get_env_str("DISCORD_CLIENT_ID", required=True)
     DISCORD_CLIENT_SECRET: str = get_env_str("DISCORD_CLIENT_SECRET", required=True)

--- a/tests/test_module_champion.py
+++ b/tests/test_module_champion.py
@@ -10,9 +10,20 @@ class FakeWebhook:
         self.called = False
         self.kwargs = {}
 
-    def send(self, content: str, webhook_url=None, file_path=None):
+    def send(
+        self,
+        content: str,
+        webhook_url=None,
+        file_path=None,
+        *,
+        event_channel=False,
+    ):
         self.called = True
-        self.kwargs = {"content": content, "file_path": file_path}
+        self.kwargs = {
+            "content": content,
+            "file_path": file_path,
+            "event_channel": event_channel,
+        }
         # ensure file exists
         assert file_path and Path(file_path).is_file()
         return True

--- a/tests/test_module_weekly_report.py
+++ b/tests/test_module_weekly_report.py
@@ -29,9 +29,17 @@ class FakeWebhook:
         self.url = url
         self.sent = False
 
-    def send(self, content: str, webhook_url=None, file_path=None):
+    def send(
+        self,
+        content: str,
+        webhook_url=None,
+        file_path=None,
+        *,
+        event_channel=False,
+    ):
         self.sent = True
         assert content.startswith("```")
+        assert event_channel is False
         return True
 
 


### PR DESCRIPTION
## Summary
- add `DISCORD_EVENT_CHANNEL_ID` configuration option
- allow `WebhookAgent.send` to send messages to the event channel
- attach generated event posters when posting events via the admin UI
- keep champion announcements and weekly reports on the standard webhook
- adapt tests for updated webhook interface

## Testing
- `isort . && black . && flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b7806b3ac8324a76701b4aa42b5ba