### PR TITLE
Fix event form handling

### DIFF
--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -46,7 +46,7 @@ def calendar():
 def create_event():
     if request.method == "POST":
         title = request.form.get("title")
-        event_time = request.form.get("event_time")
+        event_time = request.form.get("event_date")
         description = request.form.get("description")
         try:
             db["events"].insert_one(
@@ -105,7 +105,7 @@ def edit_event():
         update = {
             "title": request.form.get("title"),
             "description": request.form.get("description"),
-            "event_date": request.form.get("event_date"),
+            "event_time": request.form.get("event_date"),
             "role": request.form.get("role"),
             "recurrence": request.form.get("recurrence"),
             "updated_at": datetime.utcnow(),
@@ -124,7 +124,7 @@ def edit_event():
 @r4_required
 @admin.route("/events")
 def events():
-    rows = list(db["events"].find().sort("event_date", 1))
+    rows = list(db["events"].find().sort("event_time", 1))
     for row in rows:
         row["id"] = str(row.get("_id"))
     return render_template("admin/events.html", events=rows)
@@ -288,7 +288,7 @@ def post_event(event_id: str):
         return redirect(url_for("admin.events"))
 
     content = (
-        f"📅 **{event.get('title')}**\n{event.get('description', '')}\n🕒 {event.get('event_date')}"
+        f"📅 **{event.get('title')}**\n{event.get('description', '')}\n🕒 {event.get('event_time')}"
     )
     webhook = WebhookAgent(Config.DISCORD_WEBHOOK_URL)
     success = webhook.send(content)

--- a/blueprints/public.py
+++ b/blueprints/public.py
@@ -177,7 +177,7 @@ def calendar():
 
 @public.route("/events")
 def events():
-    rows = list(db["events"].find().sort("event_date", 1))
+    rows = list(db["events"].find().sort("event_time", 1))
     return render_template("public/events_list.html", events=rows)
 
 

--- a/templates/admin/edit_event.html
+++ b/templates/admin/edit_event.html
@@ -16,7 +16,7 @@
 
     <label for="event_date">{{ t("Datum & Uhrzeit") }}</label>
     <input type="datetime-local" id="event_date" name="event_date"
-           value="{{ event.get('event_date', '').replace(' ', 'T') }}" required>
+           value="{{ event.get('event_time', '').replace(' ', 'T') }}" required>
 
     <label for="role">{{ t("Zielrolle") }}</label>
     <input type="text" id="role" name="role" value="{{ event.get('role', '') }}">

--- a/templates/admin/events.html
+++ b/templates/admin/events.html
@@ -10,7 +10,7 @@
     {% for e in events %}
       <li class="event-item">
         <strong>{{ e.title }}</strong>
-        <span class="event-date">({{ e.event_date.strftime('%Y-%m-%d %H:%M') if e.event_date else '–' }})</span>
+        <span class="event-date">({{ e.event_time.strftime('%Y-%m-%d %H:%M') if e.event_time else '–' }})</span>
 
         <div class="event-actions">
           <a class="btn btn-glow" href="{{ url_for('admin.edit_event', id=e.id|string) }}">✏️ {{ t("Bearbeiten") }}</a>

--- a/templates/public/events.html
+++ b/templates/public/events.html
@@ -29,7 +29,7 @@
           <tr>
             <td>{{ event.title }}</td>
             <td>{{ event.description[:80] }}{% if event.description|length > 80 %}...{% endif %}</td>
-            <td>{{ event.event_date }}</td>
+            <td>{{ event.event_time }}</td>
             {% if session.get("user") %}
               <td>
                 <form action="{{ url_for('public.join_event', event_id=event.id) }}" method="POST" style="display:inline;">

--- a/templates/public/events_list.html
+++ b/templates/public/events_list.html
@@ -27,7 +27,7 @@
             <tr>
               <td>{{ event.title }}</td>
               <td>{{ event.description[:80] }}{% if event.description|length > 80 %}…{% endif %}</td>
-              <td>{{ event.event_date }}</td>
+              <td>{{ event.event_time }}</td>
               {% if session.get("user") %}
                 <td>
                   <form action="{{ url_for('public.join_event', event_id=event.id) }}" method="POST" style="display:inline;">

--- a/tests/test_admin_auth.py
+++ b/tests/test_admin_auth.py
@@ -69,7 +69,7 @@ def test_post_event_requires_r4(client):
     admin_mod.db = mongo_service.db
     collection = mongo_service.db["events"]
     event_id = collection.insert_one(
-        {"title": "T", "description": "d", "event_date": "soon"}
+        {"title": "T", "description": "d", "event_time": "soon"}
     ).inserted_id
     resp = _check_requires_r4(client, "POST", f"/admin/events/post/{event_id}")
     assert resp.status_code == 302


### PR DESCRIPTION
## Summary
- store event date as `event_time`
- update admin/public pages to display `event_time`
- post events using `event_time`
- fix tests for new field

## Testing
- `pytest --disable-warnings --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_685b78065aa48324b91439ad5471001e