### PR TITLE
Add diagnostic utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,18 @@ This repository contains the Rabbit FUR system.
 
 The admin interface provides a **Memory Viewer** at `/admin/memory` to inspect GPT memory dumps. Access is restricted to admin users. A placeholder screenshot can be placed in `docs/screenshots/memory-viewer.png`.
 
+## Diagnostic Tool
+
+Run `diagnostic_tool.py` to list recent events, configured channels, generated posters and log files.
+
+```bash
+python diagnostic_tool.py --events --channels --posters --logs
+```
+
+Options can be combined as needed:
+
+- `--events` – show today's events
+- `--channels` – print channel mappings from `config.py`
+- `--posters` – list poster image files
+- `--logs` – list markdown log files
+

--- a/diagnostic_tool.py
+++ b/diagnostic_tool.py
@@ -1,0 +1,86 @@
+"""Utility to inspect events, channel mappings, poster files and logs."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+from config import Config
+from utils import event_helpers
+
+
+def get_recent_events() -> str:
+    """Return formatted events for today using :mod:`utils.event_helpers`."""
+    events = event_helpers.get_events_for(datetime.utcnow())
+    if not events:
+        return "No events found."
+    return event_helpers.format_events(events)
+
+
+def get_channel_mapping() -> dict[str, int | str | None]:
+    """Return a dict with relevant channel configuration values."""
+    return {
+        "REMINDER_CHANNEL_ID": Config.REMINDER_CHANNEL_ID,
+        "DISCORD_EVENT_CHANNEL_ID": Config.DISCORD_EVENT_CHANNEL_ID,
+        "EVENT_CHANNEL_ID": Config.EVENT_CHANNEL_ID,
+        "EVENT_REMINDER_CHANNEL": Config.EVENT_REMINDER_CHANNEL,
+        "CHAMPION_ANNOUNCEMENT_CHANNEL": Config.CHAMPION_ANNOUNCEMENT_CHANNEL,
+    }
+
+
+def get_poster_files() -> list[str]:
+    """Return a list of generated poster file paths."""
+    base = Path(Config.STATIC_FOLDER)
+    candidates = [
+        base / Config.POSTER_OUTPUT_REL_PATH,
+        base / Config.CHAMPION_OUTPUT_REL_PATH,
+        base / "generated",
+    ]
+    files: list[str] = []
+    for directory in candidates:
+        if directory.is_dir():
+            files.extend(str(p) for p in directory.glob("*.png"))
+    return files
+
+
+def get_log_files(log_dir: str | Path = "core/logs") -> list[str]:
+    """Return Markdown log files from *log_dir*."""
+    path = Path(log_dir)
+    if not path.is_dir():
+        return []
+    return [str(p) for p in sorted(path.glob("*.md"))]
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="FUR diagnostic utility")
+    parser.add_argument("--events", action="store_true", help="Show recent events")
+    parser.add_argument("--channels", action="store_true", help="Show channel mappings")
+    parser.add_argument("--posters", action="store_true", help="List poster files")
+    parser.add_argument("--logs", action="store_true", help="List log files")
+    args = parser.parse_args(args=argv)
+
+    if not any(vars(args).values()):
+        parser.print_help()
+        return
+
+    if args.events:
+        print("== Recent Events ==")
+        print(get_recent_events())
+    if args.channels:
+        print("== Channel Mappings ==")
+        for key, value in get_channel_mapping().items():
+            print(f"{key}: {value}")
+    if args.posters:
+        print("== Poster Files ==")
+        for item in get_poster_files():
+            print(item)
+    if args.logs:
+        print("== Log Files ==")
+        for item in get_log_files():
+            print(item)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/tests/test_diagnostic_tool.py
+++ b/tests/test_diagnostic_tool.py
@@ -1,0 +1,48 @@
+import diagnostic_tool as mod
+from config import Config
+
+
+def test_get_channel_mapping(monkeypatch):
+    monkeypatch.setattr(Config, "REMINDER_CHANNEL_ID", 1)
+    monkeypatch.setattr(Config, "DISCORD_EVENT_CHANNEL_ID", 2)
+    monkeypatch.setattr(Config, "EVENT_CHANNEL_ID", 3)
+    monkeypatch.setattr(Config, "EVENT_REMINDER_CHANNEL", "events")
+    monkeypatch.setattr(Config, "CHAMPION_ANNOUNCEMENT_CHANNEL", "announcements")
+
+    mapping = mod.get_channel_mapping()
+    assert mapping["REMINDER_CHANNEL_ID"] == 1
+    assert mapping["DISCORD_EVENT_CHANNEL_ID"] == 2
+    assert mapping["EVENT_CHANNEL_ID"] == 3
+
+
+def test_get_poster_files(monkeypatch, tmp_path):
+    monkeypatch.setattr(Config, "STATIC_FOLDER", str(tmp_path))
+    monkeypatch.setattr(Config, "POSTER_OUTPUT_REL_PATH", "posters")
+    monkeypatch.setattr(Config, "CHAMPION_OUTPUT_REL_PATH", "champions")
+
+    (tmp_path / "posters").mkdir()
+    (tmp_path / "posters" / "a.png").write_bytes(b"img")
+    (tmp_path / "champions").mkdir()
+    (tmp_path / "champions" / "b.png").write_bytes(b"img")
+
+    files = mod.get_poster_files()
+    assert len(files) == 2
+
+
+def test_get_log_files(tmp_path):
+    (tmp_path / "a.md").write_text("log")
+    (tmp_path / "b.md").write_text("log")
+    logs = mod.get_log_files(tmp_path)
+    assert logs == [str(tmp_path / "a.md"), str(tmp_path / "b.md")]
+
+
+def test_get_recent_events(monkeypatch):
+    def fake_get_events_for(dt):
+        return [{"title": "Test", "event_time": "2025-01-01T12:00:00"}]
+
+    def fake_format_events(ev):
+        return "ok"
+
+    monkeypatch.setattr(mod.event_helpers, "get_events_for", fake_get_events_for)
+    monkeypatch.setattr(mod.event_helpers, "format_events", fake_format_events)
+    assert mod.get_recent_events() == "ok"


### PR DESCRIPTION
## Summary
- create `diagnostic_tool.py` for inspecting recent events, channel mappings, poster files and logs
- add command-line usage instructions for the utility
- test the new diagnostic functions

## Testing
- `flake8 diagnostic_tool.py tests/test_diagnostic_tool.py`
- `pytest --disable-warnings --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_685b881a0f648324b93cf2194f4b3559