### PR TITLE
Add scheduler agent integration with background jobs

### DIFF
--- a/main_app.py
+++ b/main_app.py
@@ -16,6 +16,8 @@ from flask import Response, session
 
 # ✅ Korrekt: Agenten-Loader importieren
 from agents.agenten_loader import init_agents
+from agents.scheduler_agent import SchedulerAgent
+from config import Config
 
 # 🌍 Module
 from database import close_db
@@ -90,6 +92,13 @@ if __name__ == "__main__":
 
         # 🧠 Agenten laden (Reminder, Translation, Champion etc.)
         agents = init_agents(db=db, session=session)
+
+        scheduler = SchedulerAgent()
+        if Config.GOOGLE_CALENDAR_ID:
+            scheduler.schedule_google_sync()
+        if Config.DISCORD_WEBHOOK_URL:
+            scheduler.schedule_champion_autopilot()
+        threading.Thread(target=scheduler.run, daemon=True).start()
 
         atexit.register(cleanup)
         signal.signal(signal.SIGINT, signal_handler)

--- a/tests/test_scheduler_agent.py
+++ b/tests/test_scheduler_agent.py
@@ -1,0 +1,46 @@
+import sys
+import types
+
+
+def test_scheduler_jobs(monkeypatch):
+    schedule_mod = types.ModuleType("schedule")
+    jobs = []
+
+    class FakeEvery:
+        def __init__(self, interval):
+            self.interval = interval
+
+        @property
+        def minutes(self):
+            return self
+
+        @property
+        def hours(self):
+            return self
+
+        @property
+        def seconds(self):
+            return self
+
+        def do(self, func, *args, **kwargs):
+            jobs.append((self.interval, func))
+            return object()
+
+    schedule_mod.every = lambda interval: FakeEvery(interval)
+    sys.modules["schedule"] = schedule_mod
+
+    import importlib
+
+    agent_mod = importlib.reload(__import__("agents.scheduler_agent", fromlist=["SchedulerAgent"]))
+
+    monkeypatch.setattr(agent_mod, "start_google_sync", lambda *a, **k: None)
+    monkeypatch.setattr(agent_mod, "sync_google_calendar", lambda: None)
+    monkeypatch.setattr(agent_mod, "run_champion_autopilot", lambda **k: None)
+
+    agent = agent_mod.SchedulerAgent()
+    agent.schedule_google_sync(interval_minutes=5)
+    agent.schedule_champion_autopilot(interval_hours=1)
+
+    assert len(agent.jobs) == 2
+    assert jobs[0][0] == 5
+    assert jobs[1][0] == 1


### PR DESCRIPTION
## Summary
- wire up `SchedulerAgent` from `main_app.py`
- run Google Calendar sync and Champion autopilot loops
- add tests covering job creation in the scheduler

## Testing
- `flake8`
- `black main_app.py tests/test_scheduler_agent.py`
- `isort main_app.py tests/test_scheduler_agent.py`
- `pytest --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_685b88186c7083248623eaeb76da12e2