### PR TITLE
Unify event channel variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,6 @@ DISCORD_WEBHOOK_URL=                    # Optional Discord webhook
 DISCORD_TOKEN=your-discord-bot-token    # Discord bot token
 DISCORD_GUILD_ID=1234567890             # Discord server ID
 REMINDER_CHANNEL_ID=1234567890          # Channel ID for reminders
-DISCORD_EVENT_CHANNEL_ID=1234567890     # Optional channel ID for events
 EVENT_CHANNEL_ID=1234567890             # Channel ID for event posts
 DISCORD_CLIENT_ID=your-client-id        # OAuth client ID
 DISCORD_CLIENT_SECRET=your-client-secret  # OAuth client secret

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The FUR System powers the champion, reminder and leaderboard features for the GG
 
 Copy `.env.example` to `.env` and adjust the values for your environment before running the setup commands.
 
-Set `EVENT_CHANNEL_ID` to the Discord channel where event announcements should be posted.
+Set `EVENT_CHANNEL_ID` to the Discord channel where event announcements should be posted. This single variable replaces previous names such as `DISCORD_EVENT_CHANNEL_ID`.
 
 1. **Install the dependencies** (required before starting the app)
    ```bash

--- a/agents/webhook_agent.py
+++ b/agents/webhook_agent.py
@@ -33,13 +33,13 @@ class WebhookAgent:
         file_path:
             Optional path to an attachment.
         event_channel:
-            If ``True`` and ``Config.DISCORD_EVENT_CHANNEL_ID`` is set, the
+            If ``True`` and ``Config.EVENT_CHANNEL_ID`` is set, the
             message is posted via ``send_discord_message``.
         """
 
-        if event_channel and Config.DISCORD_EVENT_CHANNEL_ID:
+        if event_channel and Config.EVENT_CHANNEL_ID:
             try:
-                send_discord_message(Config.DISCORD_EVENT_CHANNEL_ID, content, file_path)
+                send_discord_message(Config.EVENT_CHANNEL_ID, content, file_path)
                 logging.info("📤 Event-Channel Nachricht gesendet")
                 return True
             except Exception as e:  # pragma: no cover - network failure

--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -21,9 +21,8 @@ from werkzeug.utils import secure_filename
 from agents.webhook_agent import WebhookAgent
 from config import Config
 from mongo_service import db
-from utils.discord_util import require_roles
-from utils.poster_generator import generate_event_poster
 from utils.discord_util import ENABLE_BOT, require_roles, send_discord_message
+from utils.poster_generator import generate_event_poster
 from web.auth.decorators import r4_required
 
 admin = Blueprint("admin", __name__)

--- a/config.py
+++ b/config.py
@@ -43,7 +43,6 @@ class Config:
     DISCORD_TOKEN: str = get_env_str("DISCORD_TOKEN", required=True)
     DISCORD_GUILD_ID: int = get_env_int("DISCORD_GUILD_ID", required=True)
     REMINDER_CHANNEL_ID: int = get_env_int("REMINDER_CHANNEL_ID", required=True)
-    DISCORD_EVENT_CHANNEL_ID: int | None = get_env_int("DISCORD_EVENT_CHANNEL_ID", required=False)
     EVENT_CHANNEL_ID: int | None = get_env_int("EVENT_CHANNEL_ID", required=False)
     REMINDER_ROLE_ID: int | None = get_env_int("REMINDER_ROLE_ID", required=False)
     DISCORD_CLIENT_ID: str = get_env_str("DISCORD_CLIENT_ID", required=True)


### PR DESCRIPTION
## Summary
- consolidate event posting env variable
- update Config and refactor WebhookAgent
- tweak admin blueprint imports
- document the single EVENT_CHANNEL_ID variable
- clean up `.env.example`

## Testing
- `flake8`
- `pytest --disable-warnings --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_685b8817613c8324ba647914dcca8b1e