### PR TITLE
Fix event posting double send

### DIFF
--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -23,7 +23,6 @@ from config import Config
 from mongo_service import db
 from utils.discord_util import require_roles
 from utils.poster_generator import generate_event_poster
-from utils.discord_util import ENABLE_BOT, require_roles, send_discord_message
 from web.auth.decorators import r4_required
 
 admin = Blueprint("admin", __name__)
@@ -296,22 +295,6 @@ def post_event(event_id: str):
     webhook = WebhookAgent(Config.DISCORD_WEBHOOK_URL)
     poster = generate_event_poster(event)
     success = webhook.send(content, file_path=poster, event_channel=True)
-    if success:
-        flash("Event gepostet", "success")
-    else:
-        flash("Fehler beim Posten", "danger")
-
-    success = False
-    try:
-        if ENABLE_BOT:
-            asyncio.run(send_discord_message(Config.EVENT_CHANNEL_ID, content))
-            success = True
-        else:
-            webhook = WebhookAgent(Config.DISCORD_WEBHOOK_URL)
-            success = webhook.send(content)
-    except Exception as exc:  # noqa: BLE001
-        current_app.logger.error("Event post failed: %s", exc, exc_info=True)
-
     flash("Event gepostet" if success else "Fehler beim Posten", "success" if success else "danger")
     return redirect(url_for("admin.events"))
 

--- a/tests/test_event_post_message.py
+++ b/tests/test_event_post_message.py
@@ -1,0 +1,41 @@
+import importlib
+from pathlib import Path
+
+import mongo_service
+from tests.test_admin_auth import login_with_role
+
+
+class FakeWebhook:
+    def __init__(self, url):
+        self.url = url
+        self.calls = 0
+
+    def send(self, content: str, webhook_url=None, file_path=None, *, event_channel=False):
+        self.calls += 1
+        assert Path(file_path).is_file()
+        return True
+
+
+def test_post_event_single_message(client, monkeypatch, tmp_path):
+    admin_mod = importlib.import_module("blueprints.admin")
+    admin_mod.db = mongo_service.db
+
+    poster = tmp_path / "poster.png"
+    poster.write_text("img")
+
+    event_id = (
+        admin_mod.db["events"]
+        .insert_one({"title": "T", "description": "d", "event_time": "soon"})
+        .inserted_id
+    )
+
+    fake = FakeWebhook("http://example.com")
+    monkeypatch.setattr(admin_mod, "WebhookAgent", lambda url: fake)
+    monkeypatch.setattr(admin_mod, "generate_event_poster", lambda event: str(poster))
+
+    login_with_role(client, "R4")
+    resp = client.post(f"/admin/events/post/{event_id}")
+    assert resp.status_code == 302
+    assert fake.calls == 1
+
+    admin_mod.db["events"].delete_one({"_id": event_id})


### PR DESCRIPTION
## Summary
- prevent admin event route from sending the message twice
- add regression test for single send

## Testing
- `black tests/test_event_post_message.py blueprints/admin.py`
- `isort tests/test_event_post_message.py blueprints/admin.py`
- `flake8`
- `pytest tests/test_event_post_message.py -q`
- ❌ `pytest -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_685b8815d65c8324847682dd593843d1