### PR TITLE
Fix all-day event UTC handling

### DIFF
--- a/tests/test_google_sync.py
+++ b/tests/test_google_sync.py
@@ -78,3 +78,23 @@ def test_sync_google_calendar(monkeypatch):
     mod.sync_google_calendar()
     assert called["calendar_id"] == "test"
     assert called["imported"][0]["id"] == "g2"
+
+
+def test_import_all_day_event_time(monkeypatch):
+    dummy = DummyCollection()
+    monkeypatch.setattr(mod, "get_collection", lambda name: dummy)
+
+    events = [
+        {
+            "id": "g3",
+            "summary": "All Day",
+            "start": {"date": "2025-01-03"},
+            "end": {"date": "2025-01-04"},
+            "updated": "2025-01-02T09:00:00Z",
+        }
+    ]
+
+    mod.import_events(events)
+    doc = dummy.docs["g3"]
+    assert doc["event_time"].hour == 0
+    assert doc["event_time"].tzinfo == timezone.utc

--- a/utils/google_sync.py
+++ b/utils/google_sync.py
@@ -74,7 +74,7 @@ def import_events(events: Iterable[dict]) -> None:
         event_time = start_dt
         if event_time:
             if event_time.tzinfo is None:
-                event_time = datetime.utcfromtimestamp(event_time.timestamp())
+                event_time = event_time.replace(tzinfo=timezone.utc)
             else:
                 event_time = event_time.astimezone(timezone.utc)
 


### PR DESCRIPTION
## Summary
- preserve midnight UTC when parsing all-day Google Calendar events
- test import of all-day events to ensure UTC midnight

## Testing
- `flake8 utils/google_sync.py tests/test_google_sync.py`
- `pytest tests/test_google_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_685b8813ee848324b865bbbf7b2d1689