### PR TITLE
Fix schedule import error

### DIFF
--- a/config.py
+++ b/config.py
@@ -44,6 +44,7 @@ class Config:
     DISCORD_GUILD_ID: int = get_env_int("DISCORD_GUILD_ID", required=True)
     REMINDER_CHANNEL_ID: int = get_env_int("REMINDER_CHANNEL_ID", required=True)
     EVENT_CHANNEL_ID: int | None = get_env_int("EVENT_CHANNEL_ID", required=False)
+    DISCORD_EVENT_CHANNEL_ID: int | None = EVENT_CHANNEL_ID
     REMINDER_ROLE_ID: int | None = get_env_int("REMINDER_ROLE_ID", required=False)
     DISCORD_CLIENT_ID: str = get_env_str("DISCORD_CLIENT_ID", required=True)
     DISCORD_CLIENT_SECRET: str = get_env_str("DISCORD_CLIENT_SECRET", required=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ pydantic>=1.10.12,<2.0.0
 # 📚 Datenbank & Planung
 SQLAlchemy==2.0.41
 apscheduler
+schedule
 redis==6.1.0
 
 # 🧠 KI & Übersetzung


### PR DESCRIPTION
## Summary
- include the `schedule` library in `requirements.txt`
- expose `DISCORD_EVENT_CHANNEL_ID` in config for compatibility

## Testing
- `black .`
- `isort .`
- `flake8`
- `pytest --disable-warnings --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_685dbb1add008324a8a89156738eef52