### PR TITLE
Fix Google sync loop

### DIFF
--- a/utils/google_sync_task.py
+++ b/utils/google_sync_task.py
@@ -47,5 +47,9 @@ def start_google_sync(interval_minutes: int | None = None) -> None:
     else:
         if minutes != DEFAULT_INTERVAL_MINUTES:
             google_sync_loop.change_interval(minutes=minutes)
-        google_sync_loop.start()
+        try:
+            asyncio.get_running_loop()
+            google_sync_loop.start()
+        except RuntimeError:
+            asyncio.run(google_sync_loop.coro())
     log.info("Google sync loop started (%s min)", minutes)


### PR DESCRIPTION
## Summary
- detect missing event loop when starting the google sync task
- fall back to running the task once when no loop exists

## Testing
- `flake8 utils/google_sync_task.py`
- `pytest --disable-warnings --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_685dbd15db188324a21550b3ee584411