### PR TITLE
Fix Babel locale selector

### DIFF
--- a/web/__init__.py
+++ b/web/__init__.py
@@ -76,11 +76,10 @@ def create_app() -> Flask:
 
     babel = Babel()
 
-    @babel.localeselector
     def get_locale() -> str:  # pragma: no cover - simple accessor
         return session.get("lang") or request.accept_languages.best_match(["en", "de"])
 
-    babel.init_app(app)
+    babel.init_app(app, locale_selector=get_locale)
 
     @app.before_request
     def set_language_from_request() -> None:


### PR DESCRIPTION
## Summary
- update locale selector usage for Flask-Babel>=4

## Testing
- `black .`
- `isort .`
- `flake8`
- `pytest --disable-warnings --maxfail=1` *(fails: ServerSelectionTimeoutError)*

------
https://chatgpt.com/codex/tasks/task_e_685dc6a25374832494d0c5c51f0e8b1f