### PR TITLE
➕ Feature: localize event time formatting

### DIFF
--- a/tests/test_event_helpers.py
+++ b/tests/test_event_helpers.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import utils.event_helpers as mod
+from fur_lang import i18n
 
 
 class FakeEvents:
@@ -34,12 +35,22 @@ def test_get_events_for(monkeypatch):
     assert events[0]["title"] == "A"
 
 
-def test_format_events():
+def test_format_events(monkeypatch):
     events = [
         {"title": "X", "event_time": datetime(2025, 1, 1, 8, 0)},
         {"title": "Y", "event_time": "2025-01-02T09:00:00"},
     ]
+    monkeypatch.setattr(i18n, "current_lang", lambda: "de")
+    monkeypatch.setattr(
+        i18n,
+        "t",
+        lambda key, default=None, lang=None, **kwargs: {"prefix_utc": "UTC"}.get(
+            key,
+            default or key,
+        ),
+    )
     text = mod.format_events(events)
     assert "- X" in text
     assert "01.01.2025" in text
     assert "02.01.2025" in text
+    assert text.endswith("UTC")

--- a/translation_keys.json
+++ b/translation_keys.json
@@ -306,5 +306,6 @@
     "cmd_newsletter_stop_desc",
     "newsletter_optout_success",
     "newsletter_optout_error",
-  "hello"
+    "prefix_utc",
+    "hello",
 ]

--- a/translations/de.json
+++ b/translations/de.json
@@ -312,5 +312,6 @@
     "cmd_dm_all_param_text_desc": "Nachricht (max 2000 Zeichen)",
     "cmd_newsletter_stop_name": "newsletter_stop",
     "cmd_newsletter_stop_desc": "Deaktiviert den wöchentlichen Newsletter für dich.",
-    "Zurück": "Zurück"
+    "prefix_utc": "UTC",
+    "Zurück": "Zurück",
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -312,5 +312,6 @@
     "cmd_dm_all_param_text_desc": "Message (max 2000 characters)",
     "cmd_newsletter_stop_name": "newsletter_stop",
     "cmd_newsletter_stop_desc": "Disable the weekly newsletter for you.",
-    "Zurück": "Zurück"
+    "prefix_utc": "UTC",
+    "Zurück": "Zurück",
 }

--- a/utils/event_helpers.py
+++ b/utils/event_helpers.py
@@ -4,6 +4,9 @@ from datetime import date as date_type
 from datetime import datetime, timedelta
 from typing import Any, Iterable
 
+from babel.dates import format_datetime
+
+from fur_lang import i18n
 from mongo_service import get_collection
 
 
@@ -38,10 +41,13 @@ def get_events_for(dt: datetime | date_type) -> list[dict]:
 def format_events(events: Iterable[dict]) -> str:
     """Return a newline separated bullet list for the given events."""
     lines = []
+    lang = i18n.current_lang()
+    tz_prefix = i18n.t("prefix_utc", default="UTC", lang=lang)
     for ev in events:
         dt = parse_event_time(ev.get("event_time"))
         if not dt:
             continue
         title = ev.get("title", "Event")
-        lines.append(f"- {title} – {dt.strftime('%d.%m.%Y %H:%M')} UTC")
+        dt_text = format_datetime(dt, "dd.MM.yyyy HH:mm", locale=lang)
+        lines.append(f"- {title} – {dt_text} {tz_prefix}")
     return "\n".join(lines)


### PR DESCRIPTION
## Summary
- format event date/time using Babel with current language
- translate timezone prefix via `prefix_utc` key
- extend translation files and keys
- adjust unit tests for localized format

## Testing
- `black utils/event_helpers.py tests/test_event_helpers.py translations/en.json translations/de.json translation_keys.json`
- `isort utils/event_helpers.py tests/test_event_helpers.py`
- `flake8 utils/event_helpers.py tests/test_event_helpers.py`
- `pytest -q tests/test_event_helpers.py`


------
https://chatgpt.com/codex/tasks/task_e_685e01578fe88324aa9ebb1a9c610266