### PR TITLE
Add socketio namespace for events

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "pymongo>=4.7.0",
   "pydantic>=2.6.4",
   "Flask-Babel>=2.0.0",
+  "Flask-SocketIO>=5.3",
   "python-dotenv>=1.0.1",
   "Markdown>=3.0",
   "google-api-python-client>=2.125.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,9 @@ flask==2.3.3
 Flask-Session==0.8.0
 flask-babel @ git+https://github.com/python-babel/flask-babel.git
 flask-wtf
-flask-limiter
 pymongo==4.3.3
+flask-limiter
+Flask-SocketIO
 pydantic>=1.10.12,<2.0.0
 
 # 📚 Datenbank & Planung

--- a/static/js/event_updates.js
+++ b/static/js/event_updates.js
@@ -1,0 +1,21 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const socket = io('/updates');
+
+  socket.on('new_event', function (data) {
+    const list = document.getElementById('event-updates');
+    if (list) {
+      const item = document.createElement('li');
+      item.textContent = data.title || JSON.stringify(data);
+      list.appendChild(item);
+    }
+  });
+
+  socket.on('new_reminder', function (data) {
+    const list = document.getElementById('reminder-updates');
+    if (list) {
+      const item = document.createElement('li');
+      item.textContent = data.message || JSON.stringify(data);
+      list.appendChild(item);
+    }
+  });
+});

--- a/tests/test_socketio_updates.py
+++ b/tests/test_socketio_updates.py
@@ -1,0 +1,12 @@
+from web.socketio_events import emit_new_event, emit_new_reminder, socketio
+
+
+def test_event_emission(app):
+    client = socketio.test_client(app, namespace="/updates")
+    emit_new_event({"title": "PyCon"})
+    received = client.get_received("/updates")
+    assert any(r["name"] == "new_event" and r["args"][0]["title"] == "PyCon" for r in received)
+    emit_new_reminder({"message": "Soon"})
+    received = client.get_received("/updates")
+    assert any(r["name"] == "new_reminder" for r in received)
+    client.disconnect(namespace="/updates")

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -13,6 +13,7 @@ from fur_lang.i18n import current_lang, get_supported_languages, t
 from web.champion_routes import champion_blueprint
 from web.poster_routes import poster_blueprint
 from web.reminder_routes import reminder_blueprint
+from web.socketio_events import init_socketio
 
 # ---------------------------------------------------------------------------
 # 🔹 Hilfsfunktion (Fallback für BG-Resolver)
@@ -151,5 +152,5 @@ def create_app() -> Flask:
         app.logger.error(
             "❌ landing.html nicht gefunden! Kontrolliere den Pfad (%s).", landing_path
         )
-
+    init_socketio(app)
     return app

--- a/web/socketio_events.py
+++ b/web/socketio_events.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from flask_socketio import Namespace, SocketIO, emit
+
+socketio = SocketIO(async_mode="threading")
+
+
+class UpdatesNamespace(Namespace):
+    def on_connect(self) -> None:
+        emit("connected", {"status": "ok"})
+
+    def on_disconnect(self) -> None:  # pragma: no cover - no logic
+        pass
+
+
+def init_socketio(app) -> SocketIO:
+    socketio.init_app(app)
+    socketio.on_namespace(UpdatesNamespace("/updates"))
+    return socketio
+
+
+def emit_new_event(event: dict) -> None:
+    socketio.emit("new_event", event, namespace="/updates")
+
+
+def emit_new_reminder(reminder: dict) -> None:
+    socketio.emit("new_reminder", reminder, namespace="/updates")


### PR DESCRIPTION
## Summary
- add `flask_socketio` dependency
- expose socket.io namespace in `web`
- emit updates for new events and reminders
- connect from browser via new JS helper
- cover socket emission with unit tests

## Testing
- `black .`
- `isort .`
- `flake8`
- `pytest -q` *(fails: ServerSelectionTimeoutError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_685e0158be74832490c5d797c2116123