### PR TITLE
Update i18n fallback & language UX

### DIFF
--- a/config.py
+++ b/config.py
@@ -69,7 +69,7 @@ class Config:
     ).split(",")
 
     # --- i18n ---
-    BABEL_DEFAULT_LOCALE = "de"
+    BABEL_DEFAULT_LOCALE = "en"
     BABEL_SUPPORTED_LOCALES = get_supported_languages()
     SUPPORTED_LANGUAGES: list[str] = [
         "en",

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ current_lang() }}">
+<html lang="{{ current_lang() }}" dir="{{ 'rtl' if is_rtl(current_lang()) else 'ltr' }}">
 <head>
   <meta charset="UTF-8">
   <title>{% block title %}MATRIX System by FUR{% endblock %}</title>
@@ -104,7 +104,7 @@
             data-flag="{{ url_for('static', filename='flags/' + lang + '.png') }}"
             {% if session.get('lang') == lang %}selected{% endif %}
           >
-            {{ lang.upper() }}
+            {{ language_native_name(lang) }}
           </option>
         {% endfor %}
       </select>

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -9,7 +9,13 @@ from flask import Blueprint, Flask, request, session
 from config import Config
 from database import close_db
 from flask_babel_next import Babel
-from fur_lang.i18n import current_lang, get_supported_languages, t
+from fur_lang.i18n import (
+    current_lang,
+    get_language_native_name,
+    get_supported_languages,
+    is_rtl,
+    t,
+)
 from web.champion_routes import champion_blueprint
 from web.poster_routes import poster_blueprint
 from web.reminder_routes import reminder_blueprint
@@ -78,7 +84,11 @@ def create_app() -> Flask:
     babel = Babel()
 
     def get_locale() -> str:  # pragma: no cover - simple accessor
-        return session.get("lang") or request.accept_languages.best_match(["en", "de"])
+        return (
+            session.get("lang")
+            or request.accept_languages.best_match(app.config.get("BABEL_SUPPORTED_LOCALES", []))
+            or app.config.get("BABEL_DEFAULT_LOCALE", "en")
+        )
 
     babel.init_app(app, locale_selector=get_locale)
 
@@ -94,6 +104,8 @@ def create_app() -> Flask:
             "t": t,
             "current_lang": current_lang,
             "resolve_background_template": resolve_background_template,
+            "language_native_name": get_language_native_name,
+            "is_rtl": is_rtl,
         }
 
     # ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- switch global fallback language to English
- add helpers for native language names and RTL detection
- expose helpers in Flask app context
- use native names in language dropdown and set page direction

## Testing
- `black fur_lang/i18n.py web/__init__.py config.py`
- `isort fur_lang/i18n.py web/__init__.py config.py`
- `flake8 fur_lang/i18n.py web/__init__.py config.py`
- `pytest --disable-warnings --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_685e2f10deb483248ec28c494ca163f7