### PR TITLE
Implement hourly channel reminder

### DIFF
--- a/bot/cogs/hourly_reminder_cog.py
+++ b/bot/cogs/hourly_reminder_cog.py
@@ -1,0 +1,61 @@
+import logging
+from datetime import datetime, timedelta
+from typing import Dict
+
+import discord
+from discord.ext import commands, tasks
+
+from config import Config
+from fur_lang.i18n import t
+from mongo_service import get_collection
+
+log = logging.getLogger(__name__)
+
+
+def get_open_tasks(channel_id: int) -> int:
+    """Return the number of open tasks for a channel."""
+    try:
+        collection = get_collection("tasks")
+        return collection.count_documents({"channel_id": channel_id, "status": "open"})
+    except Exception:
+        log.warning("tasks collection missing or inaccessible")
+        return 0
+
+
+class HourlyReminderCog(commands.Cog):
+    """Send hourly task reminders in a public channel."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self._last_sent: Dict[int, datetime] = {}
+        self.reminder_loop.start()
+
+    def cog_unload(self) -> None:
+        self.reminder_loop.cancel()
+
+    @tasks.loop(minutes=1)
+    async def reminder_loop(self) -> None:
+        await self.bot.wait_until_ready()
+        channel = self.bot.get_channel(Config.REMINDER_CHANNEL_ID)
+        if not channel:
+            log.warning("Reminder channel not found")
+            return
+
+        now = datetime.utcnow()
+        last = self._last_sent.get(channel.id)
+        if last and now - last < timedelta(hours=1):
+            return
+
+        if get_open_tasks(channel.id) <= 0:
+            return
+
+        msg = t("reminder_hourly", lang="en", time=now.strftime("%H:%M"))
+        try:
+            await channel.send(msg)
+            self._last_sent[channel.id] = now
+        except discord.DiscordException as exc:  # noqa: BLE001
+            log.error("Failed to send reminder: %s", exc)
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(HourlyReminderCog(bot))

--- a/tests/test_hourly_reminder.py
+++ b/tests/test_hourly_reminder.py
@@ -1,0 +1,73 @@
+import asyncio
+import types
+from datetime import datetime
+
+import pytest
+
+from bot.cogs import hourly_reminder_cog as rem_mod
+
+
+def fake_t(key, *, lang="en", **kwargs):
+    if key == "reminder_hourly":
+        return f"Reminder: {kwargs.get('time')} UTC"
+    return key
+
+
+class DummyChannel:
+    def __init__(self, cid=1):
+        self.id = cid
+        self.message = None
+
+    async def send(self, msg):
+        self.message = msg
+
+
+class DummyCollection:
+    def __init__(self, count=0):
+        self.count = count
+
+    def count_documents(self, _filter):
+        return self.count
+
+
+@pytest.mark.asyncio
+async def test_sends_if_open_tasks(monkeypatch):
+    channel = DummyChannel()
+
+    async def ready():
+        return None
+
+    bot = types.SimpleNamespace(wait_until_ready=ready, get_channel=lambda cid: channel)
+
+    monkeypatch.setattr(rem_mod.tasks.Loop, "start", lambda self, *a, **k: None)
+    monkeypatch.setattr(rem_mod, "t", fake_t)
+    monkeypatch.setattr(rem_mod, "get_collection", lambda name: DummyCollection(count=1))
+    now = datetime.utcnow()
+    monkeypatch.setattr(rem_mod, "datetime", types.SimpleNamespace(utcnow=lambda: now))
+
+    cog = rem_mod.HourlyReminderCog(bot)
+    await cog.reminder_loop()
+
+    assert channel.message and "UTC" in channel.message
+
+
+@pytest.mark.asyncio
+async def test_no_send_if_recent(monkeypatch):
+    channel = DummyChannel()
+
+    async def ready():
+        return None
+
+    bot = types.SimpleNamespace(wait_until_ready=ready, get_channel=lambda cid: channel)
+
+    monkeypatch.setattr(rem_mod.tasks.Loop, "start", lambda self, *a, **k: None)
+    monkeypatch.setattr(rem_mod, "t", fake_t)
+    monkeypatch.setattr(rem_mod, "get_collection", lambda name: DummyCollection(count=1))
+    now = datetime.utcnow()
+    monkeypatch.setattr(rem_mod, "datetime", types.SimpleNamespace(utcnow=lambda: now))
+
+    cog = rem_mod.HourlyReminderCog(bot)
+    cog._last_sent[channel.id] = now
+    await cog.reminder_loop()
+
+    assert channel.message is None


### PR DESCRIPTION
## Summary
- add hourly reminder cog posting to the configured channel
- include unit tests for hourly reminders

## Testing
- `flake8 bot/cogs/hourly_reminder_cog.py tests/test_hourly_reminder.py`
- `pytest tests/test_hourly_reminder.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685e41e0cc788324ac69105a8bccb8ca