### PR TITLE
Fix JSON and OAuth defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,5 +19,5 @@ POSTER_OUTPUT_PATH=static/posters       # Directory for generated posters
 GOOGLE_CALENDAR_ID=                     # Optional Google calendar ID
 GOOGLE_SYNC_INTERVAL_MINUTES=2          # Sync interval in minutes
 GOOGLE_REDIRECT_URI=http://localhost:8080/oauth2callback  # OAuth redirect URL
-GOOGLE_CREDENTIALS_FILE=google_credentials.json           # Token store path
+GOOGLE_CREDENTIALS_FILE=credentials/oauth_client.json    # OAuth credentials path
 GOOGLE_CALENDAR_SCOPES=https://www.googleapis.com/auth/calendar.readonly

--- a/config.py
+++ b/config.py
@@ -62,7 +62,11 @@ class Config:
         "GOOGLE_SYNC_INTERVAL_MINUTES", required=False, default=2
     )
     GOOGLE_REDIRECT_URI: str | None = get_env_str("GOOGLE_REDIRECT_URI", required=False)
-    GOOGLE_CREDENTIALS_FILE: str | None = get_env_str("GOOGLE_CREDENTIALS_FILE", required=False)
+    GOOGLE_CREDENTIALS_FILE: str | None = get_env_str(
+        "GOOGLE_CREDENTIALS_FILE",
+        required=False,
+        default=os.path.join(basedir, "credentials", "oauth_client.json"),
+    )
     GOOGLE_CALENDAR_SCOPES: list[str] = get_env_str(
         "GOOGLE_CALENDAR_SCOPES",
         default="https://www.googleapis.com/auth/calendar.readonly",

--- a/tests/test_hourly_reminder.py
+++ b/tests/test_hourly_reminder.py
@@ -1,4 +1,3 @@
-import asyncio
 import types
 from datetime import datetime
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -393,7 +393,7 @@
   "unknown_event": "unknown_event",
   "weekly_overview": "Weekly overview",
   "weekly_report_posted": "weekly_report_posted",
-  "weekly_report_title": "Weekly report"
+  "weekly_report_title": "Weekly report",
     "404 - Seite nicht gefunden": "404 - Page not found",
     "Admin": "Admin",
     "Admin Dashboard": "Admin Dashboard",


### PR DESCRIPTION
## Summary
- add default path for Google OAuth credentials
- update example .env accordingly
- remove unused import from reminder test
- fix invalid comma in English translation file

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685edd6d79f8832495abd30b2caddd27