### PR TITLE
Fix Google auth crash on config-only credentials

### DIFF
--- a/google_auth.py
+++ b/google_auth.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 from typing import Optional
 
@@ -35,7 +36,11 @@ def load_credentials() -> Optional[Credentials]:
         "GOOGLE_CALENDAR_SCOPES",
         ["https://www.googleapis.com/auth/calendar.readonly"],
     )
-    creds = Credentials.from_authorized_user_info(data, scopes)
+    try:
+        creds = Credentials.from_authorized_user_info(data, scopes)
+    except ValueError as exc:  # invalid or client config only
+        logging.error("Main: %s", exc)
+        return None
     if creds and creds.expired and creds.refresh_token:
         creds.refresh(Request())
         _save_credentials(creds)

--- a/tests/test_google_auth.py
+++ b/tests/test_google_auth.py
@@ -71,3 +71,11 @@ def test_load_credentials_refresh(monkeypatch, tmp_path, app):
     assert isinstance(cred, FakeCred)
     assert refreshed["called"]
     assert json.loads(path.read_text())["token"] == "new"
+
+
+def test_load_credentials_invalid_returns_none(tmp_path, app):
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps({"web": {"client_id": "id"}}))
+    app.config.update(GOOGLE_CREDENTIALS_FILE=str(path), GOOGLE_CALENDAR_SCOPES=["scope"])
+
+    assert mod.load_credentials() is None


### PR DESCRIPTION
## Summary
- handle invalid credential data in `load_credentials`
- test that `load_credentials` returns `None` when credentials file is not authorized

## Testing
- `isort . && black . && flake8`
- `pytest --disable-warnings --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_685eec1f573483248de00507e2c7f68d