### PR TITLE
Add async Mongo models for users and events

### DIFF
--- a/models/event_model.py
+++ b/models/event_model.py
@@ -1,0 +1,62 @@
+from datetime import datetime
+from typing import List, Optional
+
+from bson import ObjectId
+from motor.motor_asyncio import AsyncIOMotorCollection
+from pydantic import BaseModel, Field
+
+
+class PyObjectId(ObjectId):
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, v):
+        if isinstance(v, ObjectId):
+            return v
+        return ObjectId(str(v))
+
+
+class EventModel(BaseModel):
+    id: Optional[PyObjectId] = Field(alias="_id")
+    google_id: str
+    summary: str
+    description: Optional[str] = None
+    start: datetime
+    end: datetime
+    sync_token: Optional[str] = None
+    participants: Optional[List[str]] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+    class Config:
+        allow_population_by_field_name = True
+        arbitrary_types_allowed = True
+        json_encoders = {ObjectId: str}
+
+
+class EventRepository:
+    """Async helper for Google event documents."""
+
+    def __init__(self, collection: AsyncIOMotorCollection) -> None:
+        self.collection = collection
+
+    async def create(self, event: "EventModel") -> "EventModel":
+        data = event.model_dump(by_alias=True)
+        result = await self.collection.insert_one(data)
+        event.id = result.inserted_id
+        return event
+
+    async def get_by_google_id(self, google_id: str) -> Optional["EventModel"]:
+        raw = await self.collection.find_one({"google_id": google_id})
+        return EventModel(**raw) if raw else None
+
+    async def upsert_by_google_id(self, google_id: str, updates: dict) -> bool:
+        updates["updated_at"] = datetime.utcnow()
+        result = await self.collection.update_one(
+            {"google_id": google_id},
+            {"$set": updates},
+            upsert=True,
+        )
+        return result.acknowledged

--- a/models/user_model.py
+++ b/models/user_model.py
@@ -1,0 +1,67 @@
+from datetime import datetime
+from typing import Optional
+
+from bson import ObjectId
+from motor.motor_asyncio import AsyncIOMotorCollection
+from pydantic import BaseModel, Field
+
+
+class PyObjectId(ObjectId):
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, v):
+        if isinstance(v, ObjectId):
+            return v
+        return ObjectId(str(v))
+
+
+class UserModel(BaseModel):
+    id: Optional[PyObjectId] = Field(alias="_id")
+    discord_id: str
+    access_token: Optional[str] = None
+    refresh_token: Optional[str] = None
+    token_expiry: Optional[datetime] = None
+    timezone: str = "UTC"
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+    class Config:
+        allow_population_by_field_name = True
+        arbitrary_types_allowed = True
+        json_encoders = {ObjectId: str}
+
+
+class UserRepository:
+    """Async helper for CRUD operations on the users collection."""
+
+    def __init__(self, collection: AsyncIOMotorCollection) -> None:
+        self.collection = collection
+
+    async def create(self, user: "UserModel") -> "UserModel":
+        data = user.model_dump(by_alias=True)
+        result = await self.collection.insert_one(data)
+        user.id = result.inserted_id
+        return user
+
+    async def get_by_discord_id(self, discord_id: str) -> Optional["UserModel"]:
+        raw = await self.collection.find_one({"discord_id": discord_id})
+        return UserModel(**raw) if raw else None
+
+    async def update_tokens(
+        self, discord_id: str, *, access_token: str, refresh_token: str, token_expiry: datetime
+    ) -> bool:
+        result = await self.collection.update_one(
+            {"discord_id": discord_id},
+            {
+                "$set": {
+                    "access_token": access_token,
+                    "refresh_token": refresh_token,
+                    "token_expiry": token_expiry,
+                    "updated_at": datetime.utcnow(),
+                }
+            },
+        )
+        return result.modified_count > 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "discord.py>=2.3",
   "schedule>=1.2",
   "pymongo>=4.7.0",
+  "motor>=3.4",
   "pydantic>=2.6.4",
   "Flask-Babel>=2.0.0",
   "Flask-SocketIO>=5.3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ Flask-Session==0.8.0
 flask-babel @ git+https://github.com/python-babel/flask-babel.git
 flask-wtf
 pymongo==4.3.3
+motor
 flask-limiter
 Flask-SocketIO
 pydantic>=1.10.12,<2.0.0


### PR DESCRIPTION
## Summary
- store Google events and user oauth data in MongoDB using Motor
- add `models/user_model.py` and `models/event_model.py`
- include `motor` dependency for async Mongo support

## Testing
- `pip install -r requirements.txt`
- `black models/user_model.py models/event_model.py --quiet`
- `isort models/user_model.py models/event_model.py`
- `flake8 models/user_model.py models/event_model.py`
- `pytest --disable-warnings --maxfail=1` *(fails: unexpected indent in tests/test_google_auth.py)*

------
https://chatgpt.com/codex/tasks/task_e_6861589915d88324a7ff4141998657ad