### PR TITLE
Add timezone utilities

### DIFF
--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import utils.timezone as mod
+
+
+def test_get_timezone_valid():
+    tz = mod.get_timezone("Europe/Berlin")
+    assert isinstance(tz, ZoneInfo)
+    assert tz.key == "Europe/Berlin"
+
+
+def test_get_timezone_invalid_defaults():
+    tz = mod.get_timezone("Invalid/Zone")
+    assert tz == mod.DEFAULT_TZ
+
+
+def test_convert_datetime():
+    dt = datetime(2025, 1, 1, 12, 0)
+    converted = mod.convert_datetime(dt, "America/New_York")
+    assert converted.tzinfo.key == "America/New_York"
+    assert converted.hour == 7
+
+
+def test_get_user_timezone_dict():
+    tz = mod.get_user_timezone({"timezone": "Asia/Tokyo"})
+    assert tz.key == "Asia/Tokyo"

--- a/utils/timezone.py
+++ b/utils/timezone.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from zoneinfo import ZoneInfo
+
+DEFAULT_TZ = ZoneInfo("UTC")
+
+
+def get_timezone(name: str | None) -> ZoneInfo:
+    """Return ZoneInfo for *name* or ``DEFAULT_TZ`` when invalid."""
+    if not name:
+        return DEFAULT_TZ
+    try:
+        return ZoneInfo(name)
+    except Exception:
+        return DEFAULT_TZ
+
+
+def get_user_timezone(user: Any) -> ZoneInfo:
+    """Return timezone for user object or mapping."""
+    if not user:
+        return DEFAULT_TZ
+    if isinstance(user, dict):
+        name = user.get("timezone")
+    else:
+        name = getattr(user, "timezone", None)
+    return get_timezone(name)
+
+
+def convert_datetime(dt: datetime, tz: str | ZoneInfo | None) -> datetime:
+    """Convert *dt* to timezone ``tz`` (defaults to UTC)."""
+    if isinstance(tz, str) or tz is None:
+        tz = get_timezone(tz)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(tz)


### PR DESCRIPTION
## Summary
- provide utility for timezone conversions and validation
- add unit tests for the timezone helpers

## Testing
- `flake8 utils/timezone.py tests/test_timezone.py`
- `pytest tests/test_timezone.py -q`
- `pytest --maxfail=1 -q` *(fails: IndentationError in tests/test_google_auth.py)*

------
https://chatgpt.com/codex/tasks/task_e_68615bebdc7c8324a369e5c621b8f89f