### PR TITLE
Add calendar OAuth config and logging

### DIFF
--- a/bot/cogs/calendar_cog.py
+++ b/bot/cogs/calendar_cog.py
@@ -65,6 +65,7 @@ class CalendarCog(commands.Cog):
             embed.add_field(name=ev.get("title", "-"), value=dt_str, inline=False)
         try:
             await user.send(embed=embed)
+            log.info("Sent events DM to %s with %d events", user.id, len(events))
         except discord.Forbidden:
             log.warning("DM blocked for %s", user.id)
         except Exception as exc:  # pragma: no cover - network failures

--- a/config.py
+++ b/config.py
@@ -61,6 +61,8 @@ class Config:
     GOOGLE_SYNC_INTERVAL_MINUTES: int = get_env_int(
         "GOOGLE_SYNC_INTERVAL_MINUTES", required=False, default=2
     )
+    GOOGLE_CLIENT_ID: str = get_env_str("GOOGLE_CLIENT_ID", required=True)
+    GOOGLE_CLIENT_SECRET: str = get_env_str("GOOGLE_CLIENT_SECRET", required=True)
     GOOGLE_REDIRECT_URI: str | None = get_env_str("GOOGLE_REDIRECT_URI", required=False)
     GOOGLE_CREDENTIALS_FILE: str | None = get_env_str(
         "GOOGLE_CREDENTIALS_FILE",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,8 @@ os.environ.setdefault(
     "GOOGLE_CALENDAR_SCOPES",
     "https://www.googleapis.com/auth/calendar.readonly",
 )
+os.environ.setdefault("GOOGLE_CLIENT_ID", "gid")
+os.environ.setdefault("GOOGLE_CLIENT_SECRET", "gsecret")
 
 try:
     asyncio.get_event_loop()


### PR DESCRIPTION
## Summary
- include Google OAuth ID/secret in `Config`
- improve OAuth logging in `google_auth`
- log calendar sync progress and DM reminders
- confirm DM send in `CalendarCog`
- update test env defaults

## Testing
- `black config.py google_auth.py services/calendar_service.py bot/cogs/calendar_cog.py tests/conftest.py`
- `isort config.py google_auth.py services/calendar_service.py bot/cogs/calendar_cog.py tests/conftest.py`
- `flake8`
- `pytest --disable-warnings --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_68616f23dcc0832486f0d9f9e90db6ed