### PR TITLE
Fix MongoDB name usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+MONGO_DB=FURdb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           --health-retries=5
 
     env:
-      MONGODB_URI: "mongodb://localhost:27017/furdb"
+      MONGODB_URI: "mongodb://localhost:27017/FURdb"
       FLASK_ENV: "test"
       SECRET_KEY: "test_key"
 

--- a/codex/tasks/migrate_sqlite_to_mongodb.json
+++ b/codex/tasks/migrate_sqlite_to_mongodb.json
@@ -1,6 +1,6 @@
 {
   "name": "Migrate from SQLite to MongoDB",
-  "description": "Remove all SQLite usage and fully migrate to MongoDB (furdb). Replace connection logic, queries, and data access patterns.",
+  "description": "Remove all SQLite usage and fully migrate to MongoDB (FURdb). Replace connection logic, queries, and data access patterns.",
   "source_files": [
     "init_db_core.py",
     "database/__init__.py",

--- a/core/memory/init_memory_contexts.py
+++ b/core/memory/init_memory_contexts.py
@@ -8,8 +8,9 @@ from pymongo import MongoClient
 
 # 🔧 MongoDB-Verbindung
 MONGO_URI = os.getenv("MONGODB_URI")
+MONGO_DB = os.getenv("MONGO_DB", "FURdb")
 client = MongoClient(MONGO_URI)
-db = client["furdb"]
+db = client[MONGO_DB]
 memory_collection = db["memory_contexts"]
 
 # 📦 Zu importierende Module

--- a/fur_mongo.py
+++ b/fur_mongo.py
@@ -1,6 +1,6 @@
 """
 fur_mongo.py – zentrale MongoDB-Verbindung für das FUR-System
-Verbindet sich mit der Datenbank 'furdb' und stellt globale Collection-Zugriffe bereit.
+Verbindet sich mit der Datenbank 'FURdb' und stellt globale Collection-Zugriffe bereit.
 """
 
 import logging
@@ -23,20 +23,21 @@ logging.basicConfig(level=logging.INFO)
 
 # === MongoDB-URI aus Umgebungsvariable ===
 MONGO_URI = get_env_str("MONGODB_URI", required=False)
+MONGO_DB = get_env_str("MONGO_DB", required=False, default="FURdb")
 if not MONGO_URI:
     warnings.warn(
         "MONGODB_URI not set, falling back to local MongoDB URI",
         RuntimeWarning,
     )
     logger.warning("MONGODB_URI not set, using default localhost URI")
-    MONGO_URI = "mongodb://localhost:27017/furdb"
+    MONGO_URI = "mongodb://localhost:27017/FURdb"
 
 # === Verbindung herstellen ===
 try:
     client = MongoClient(MONGO_URI, server_api=ServerApi("1"))
     client.admin.command("ping")
-    logger.info("✅ Verbindung zu MongoDB (furdb) erfolgreich.")
-    db = client["furdb"]
+    logger.info("✅ Verbindung zu MongoDB (%s) erfolgreich.", MONGO_DB)
+    db = client[MONGO_DB]
 
     # Collection-Verweise
     users = db["users"]

--- a/mongo_service.py
+++ b/mongo_service.py
@@ -2,7 +2,7 @@ import logging
 import warnings
 
 from pymongo import MongoClient
-from pymongo.errors import ConnectionFailure, ConfigurationError
+from pymongo.errors import ConfigurationError, ConnectionFailure
 
 from utils.env_helpers import get_env_str
 
@@ -19,8 +19,9 @@ if not MONGO_URI:
         RuntimeWarning,
     )
     logger.warning("MONGODB_URI not set, using default localhost URI")
-    MONGO_URI = "mongodb://localhost:27017"
-    MONGO_DB = MONGO_DB or "furdb"
+    MONGO_URI = "mongodb://localhost:27017/FURdb"
+
+MONGO_DB = MONGO_DB or "FURdb"
 
 # Sicherstellen, dass DB-Name definiert ist
 if not MONGO_DB:
@@ -30,9 +31,11 @@ if not MONGO_DB:
 client = MongoClient(MONGO_URI)
 db = client[MONGO_DB]
 logger.info("MongoDB connected: %s [DB: %s]", bool(client), MONGO_DB)
+logger.info("🔌 Verbunden mit MongoDB-Datenbank: %s", db.name)
 
 
 # --- Funktionen ---
+
 
 def test_connection() -> None:
     """Pingt den Server, um die Verbindung zu überprüfen."""

--- a/services/calendar_service.py
+++ b/services/calendar_service.py
@@ -44,7 +44,7 @@ class CalendarService:
         tokens_collection: Optional[AsyncIOMotorCollection] = None,
     ) -> None:
         self.calendar_id = calendar_id or Config.GOOGLE_CALENDAR_ID
-        uri = mongo_uri or Config.MONGODB_URI or "mongodb://localhost:27017/furdb"
+        uri = mongo_uri or Config.MONGODB_URI or "mongodb://localhost:27017/FURdb"
         if events_collection and tokens_collection:
             self.client = None
             self.events = events_collection

--- a/tests/test_mongo_defaults.py
+++ b/tests/test_mongo_defaults.py
@@ -22,9 +22,9 @@ def _reload_fur_mongo(monkeypatch):
 
 def test_mongo_service_import_without_uri(monkeypatch):
     mod = _reload_mongo_service(monkeypatch)
-    assert mod.MONGO_URI == "mongodb://localhost:27017/furdb"
+    assert mod.MONGO_URI == "mongodb://localhost:27017/FURdb"
 
 
 def test_fur_mongo_import_without_uri(monkeypatch):
     mod = _reload_fur_mongo(monkeypatch)
-    assert mod.MONGO_URI == "mongodb://localhost:27017/furdb"
+    assert mod.MONGO_URI == "mongodb://localhost:27017/FURdb"


### PR DESCRIPTION
## Summary
- use `FURdb` in workflows and defaults
- document DB name in .env.example
- fallback to `FURdb` when no DB is provided
- ensure modules use env variable instead of hardcoded name
- update tests for new DB name

## Testing
- `black . --check`
- `isort . --check-only`
- `flake8 .`
- `pytest --maxfail=1 --disable-warnings` *(fails: AssertionError in test_public_flows)*

------
https://chatgpt.com/codex/tasks/task_e_68618f73513483249d22afdbdfe4e696