### PR TITLE
Fix calendar service DB default handling

### DIFF
--- a/services/calendar_service.py
+++ b/services/calendar_service.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 from datetime import datetime, timedelta, timezone
 from typing import Any, Iterable, Optional
 
@@ -7,6 +8,7 @@ from discord.ext import tasks
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorCollection
+from pymongo.errors import ConfigurationError
 
 from config import Config
 from google_auth import load_credentials
@@ -51,7 +53,11 @@ class CalendarService:
             self.tokens = tokens_collection
         else:
             self.client = AsyncIOMotorClient(uri)
-            db = self.client.get_default_database()
+            try:
+                db = self.client.get_default_database()
+            except ConfigurationError:
+                db_name = os.getenv("MONGO_DB", "furdb")
+                db = self.client[db_name]
             self.events = db["events"]
             self.tokens = db["calendar_tokens"]
 


### PR DESCRIPTION
## Summary
- handle missing default DB in `CalendarService`

## Testing
- `flake8 services/calendar_service.py`
- `pytest --disable-warnings --maxfail=1` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6861a77549308324bb54a096fce211ff