### PR TITLE
Fix duplicate calendar command

### DIFF
--- a/bot/cogs/calendar_cog.py
+++ b/bot/cogs/calendar_cog.py
@@ -146,4 +146,7 @@ class CalendarCog(commands.Cog):
 async def setup(bot: commands.Bot) -> None:
     cog = CalendarCog(bot)
     await bot.add_cog(cog)
-    bot.tree.add_command(cog.calendar)
+    if bot.tree.get_command("calendar") is None:
+        bot.tree.add_command(cog.calendar)
+    else:
+        log.warning("Command 'calendar' already registered – skipping")

--- a/tests/test_upload_route.py
+++ b/tests/test_upload_route.py
@@ -18,7 +18,7 @@ def test_upload_success(client, tmp_path):
     assert resp.status_code == 200
     assert "pic.png" in os.listdir(tmp_path)
     flashes = get_flashes(client)
-    expected = t("file_uploaded", default="Datei hochgeladen", lang="de")
+    _ = t("file_uploaded", default="Datei hochgeladen", lang="de")
     assert any(cat == "success" for cat, _ in flashes)
 
 
@@ -35,7 +35,7 @@ def test_upload_invalid_extension(client, tmp_path):
     assert resp.status_code == 200
     assert not os.listdir(tmp_path)
     flashes = get_flashes(client)
-    expected = t("invalid_file_type", default="Ungültiger Dateityp", lang="de")
+    _ = t("invalid_file_type", default="Ungültiger Dateityp", lang="de")
     assert any(cat == "danger" for cat, _ in flashes)
 
 
@@ -68,5 +68,5 @@ def test_upload_too_large(client, tmp_path):
     assert resp.status_code == 200
     assert not os.listdir(tmp_path)
     flashes = get_flashes(client)
-    expected = t("file_too_large", default="Datei zu groß", lang="de")
+    _ = t("file_too_large", default="Datei zu groß", lang="de")
     assert any(cat == "danger" for cat, _ in flashes)


### PR DESCRIPTION
## Summary
- avoid adding the `calendar` command group twice in `CalendarCog`
- fix unused variable warnings in `test_upload_route`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861a8dfcb108324bd90d409f35184fb