### PR TITLE
Fix calendar command duplication warning

### DIFF
--- a/bot/cogs/calendar_cog.py
+++ b/bot/cogs/calendar_cog.py
@@ -144,9 +144,9 @@ class CalendarCog(commands.Cog):
 
 
 async def setup(bot: commands.Bot) -> None:
-    cog = CalendarCog(bot)
-    await bot.add_cog(cog)
-    if bot.tree.get_command("calendar") is None:
-        bot.tree.add_command(cog.calendar)
-    else:
-        log.warning("Command 'calendar' already registered – skipping")
+    """Set up the CalendarCog without duplicate command registration."""
+    if bot.get_cog("CalendarCog") is not None:
+        log.warning("CalendarCog already loaded – skipping")
+        return
+
+    await bot.add_cog(CalendarCog(bot))

--- a/tests/test_calendar_cog.py
+++ b/tests/test_calendar_cog.py
@@ -81,3 +81,18 @@ async def test_cmd_today_sends_embed(monkeypatch):
 
     assert interaction.ephemeral
     assert isinstance(interaction.user.embed, discord.Embed)
+
+
+@pytest.mark.asyncio
+async def test_setup_skips_duplicate_registration(monkeypatch):
+    from discord.ext import commands
+
+    from bot.cogs import calendar_cog as mod
+
+    bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+
+    await mod.setup(bot)
+    await mod.setup(bot)  # second call should not register again
+
+    cmds = [c for c in bot.tree.get_commands() if c.name == "calendar"]
+    assert len(cmds) == 1


### PR DESCRIPTION
## Summary
- avoid duplicate registration in `CalendarCog.setup`
- add regression test ensuring setup skips re-registration

## Testing
- `black .`
- `isort .`
- `flake8`
- `pytest tests/test_calendar_cog.py::test_setup_skips_duplicate_registration -q`
- `pytest -k calendar_cog -q`

------
https://chatgpt.com/codex/tasks/task_e_6861aab4d2748324829879790db5d169