### PR TITLE
Add Google OAuth setup script and token handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,8 @@ instance/
 .coverage
 
 # Google OAuth credentials
-credentials/oauth_client.json
+credentials/*.json
+token/
 
 # Node / Frontend (falls vorhanden)
 node_modules/

--- a/google_oauth_setup.py
+++ b/google_oauth_setup.py
@@ -1,0 +1,34 @@
+import os
+import pickle
+from pathlib import Path
+
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+
+SCOPES = ["https://www.googleapis.com/auth/calendar"]
+
+
+def main() -> None:
+    """Run OAuth flow and store token."""
+    os.makedirs("token", exist_ok=True)
+    token_path = Path("token/token.pickle")
+    creds = None
+    if token_path.exists():
+        with token_path.open("rb") as fh:
+            creds = pickle.load(fh)
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(
+                "credentials/client_secret.json", SCOPES
+            )
+            creds = flow.run_local_server(port=0)
+        with token_path.open("wb") as fh:
+            pickle.dump(creds, fh)
+    print(f"Token saved to {token_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `.gitignore` rules to exclude credentials and OAuth tokens
- create `google_oauth_setup.py` to obtain and store Google Calendar token
- load OAuth token from `token/token.pickle` in `utils.google_sync`

## Testing
- `isort google_oauth_setup.py utils/google_sync.py`
- `black google_oauth_setup.py utils/google_sync.py`
- `flake8 google_oauth_setup.py utils/google_sync.py`
- `pip install -r requirements.txt`
- `pytest --disable-warnings --maxfail=1` *(fails: ModuleNotFoundError: No module named 'agents')*

------
https://chatgpt.com/codex/tasks/task_e_6861b17906888324ad0bf0bd3eaff7ae