### PR TITLE
Add full env template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,37 @@
-MONGO_DB=furdb
+# Example environment file for local development
+
+# Flask settings
+SECRET_KEY=change-me                 # Flask session secret
+FLASK_ENV=development                # Environment: development or production
+SESSION_LIFETIME_MINUTES=60          # Session timeout in minutes
+
+# MongoDB
+MONGODB_URI=mongodb://localhost:27017/furdb  # Connection string
+MONGO_DB=furdb                               # Database name
+
+# Discord integration
+DISCORD_WEBHOOK_URL=                    # Optional webhook for notifications
+DISCORD_TOKEN=your-discord-token        # Bot token
+DISCORD_GUILD_ID=123456789012345678     # Guild ID
+REMINDER_CHANNEL_ID=123456789012345678  # Channel for reminders
+EVENT_CHANNEL_ID=                       # Channel for events (optional)
+REMINDER_ROLE_ID=                       # Role to mention for reminders
+DISCORD_CLIENT_ID=your-discord-client-id
+DISCORD_CLIENT_SECRET=your-discord-client-secret
+DISCORD_REDIRECT_URI=http://localhost:8080/oauth/discord/callback
+R3_ROLE_IDS=                            # Comma-separated list
+R4_ROLE_IDS=
+ADMIN_ROLE_IDS=
+
+# Google Calendar
+GOOGLE_CALENDAR_ID=                    # Calendar ID (optional)
+GOOGLE_SYNC_INTERVAL_MINUTES=2         # Sync interval
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+GOOGLE_REDIRECT_URI=http://localhost:8080/oauth/google/callback
+GOOGLE_CREDENTIALS_FILE=credentials/oauth_client.json
+GOOGLE_CALENDAR_SCOPES=https://www.googleapis.com/auth/calendar.readonly
+
+# Poster and web
+POSTER_OUTPUT_PATH=static/posters      # Where generated posters are stored
+BASE_URL=http://localhost:8080          # External URL of the web app

--- a/README.md
+++ b/README.md
@@ -40,18 +40,15 @@ The FUR System powers the champion, reminder and leaderboard features for the GG
 
 ## Setup
 
-Copy `.env.example` to `.env` and adjust the values for your environment before running the setup commands.
+1. **Copy `.env.example` to `.env`** – the example file lists all settings required by `Config`. Adjust the values for your environment.
+2. Set the Google OAuth credentials using the environment variables `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`. These must not be committed to version control.
+3. Set `EVENT_CHANNEL_ID` to the Discord channel where event announcements should be posted. This single variable replaces previous names such as `DISCORD_EVENT_CHANNEL_ID`.
 
-Set the Google OAuth credentials using the environment variables
-`GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`. These must not be committed to version control.
-
-Set `EVENT_CHANNEL_ID` to the Discord channel where event announcements should be posted. This single variable replaces previous names such as `DISCORD_EVENT_CHANNEL_ID`.
-
-1. **Install the dependencies** (required before starting the app)
+4. **Install the dependencies** (required before starting the app)
    ```bash
    pip install -r requirements.txt
    ```
-2. Run the lint and test suite
+5. Run the lint and test suite
    ```bash
    black . && isort . && flake8
    pytest --disable-warnings --maxfail=1


### PR DESCRIPTION
## Summary
- expand `.env.example` with all settings required in `config.py`
- explain in README that the template should be copied before running setup commands

## Testing
- `black . --quiet`
- `isort . --quiet`
- `flake8 .`
- `pytest --disable-warnings --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_6861f22bc87c8324ab342e2d77379e2e