### PR TITLE
Update README lint/test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Du agierst als KI-Entwicklungsagent in diesem Repository. Grundlage deines Hande
 
 1. **Lies die Datei vollständig** – sie definiert Build-/Test-/Lint-Prozesse, Projektstruktur, Codekonventionen und Verhalten bei PRs.
 2. **Halte dich strikt an alle Vorgaben**:
-   - Formatierungen, z. B. via `make fmt` oder `npm run format`
-   - Tests in `tests/`, z. B. via `pytest`, `npm test`, `make test`
+   - Formatierungen und Linting, z. B. via `make lint`
+   - Tests in `tests/`, z. B. via `pytest` oder `make test`
    - PRs mit klarer Beschreibung und referenzierten Issues
    - Codeänderungen gemäß Struktur: `src/`, `lib/`, `docs/`, `scripts/`
 3. **Verhalte dich wie ein Reviewer**: Kommentiere, begründe Änderungen, reagiere auf Reviews.


### PR DESCRIPTION
## Summary
- fix references to nonexistent `make fmt`, `npm run format` and `npm test`
- clarify that linting and tests are run via `make lint` and `make test`

## Testing
- `make lint` *(fails: F401 unused imports)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6861f231e0088324b031ee3f34128e56