### PR TITLE
Add memory viewer

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -238,3 +238,10 @@ html[lang="tr"] body {
     width: 100%;
   }
 }
+
+/* === MEMORY TABLE === */
+table { width:100%; border-collapse: collapse; }
+th, td { padding: 0.5rem; text-align:left; }
+.source-mongo { background: rgba(0,255,204,0.05); }
+.source-session { background: rgba(255,255,0,0.05); }
+

--- a/templates/admin/memory/index.html
+++ b/templates/admin/memory/index.html
@@ -1,38 +1,61 @@
 {% extends 'admin/admin_base.html' %}
-
-{% block title %}🧠 {{ t('Memory Viewer') }}{% endblock %}
+{% set bg_image = '/static/bg/admin_memory.png' %}
+{% block title %}{{ t('Memory Viewer') }}{% endblock %}
 
 {% block content %}
-<div class="memory-panel">
-  <h1>🧠 {{ t('GPT Memory Log Viewer') }}</h1>
-  <p>{{ t('Hier siehst du alle gespeicherten Reflexionen, Logs und Speicherstände des Systems.') }}</p>
-
-  <table class="memory-table">
-    <thead>
-      <tr>
-        <th>📅 {{ t('Datum') }}</th>
-        <th>📁 {{ t('Typ') }}</th>
-        <th>🧠 {{ t('Version') }}</th>
-        <th>🔖 {{ t('Tags') }}</th>
-        <th>🔗 {{ t('Aktion') }}</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for entry in memory_entries %}
-      <tr>
-        <td>{{ entry.exported_at.strftime('%Y-%m-%d %H:%M') }}</td>
-        <td>{{ entry.type }}</td>
-        <td>{{ entry.version }}</td>
-        <td>{{ entry.tags | join(', ') }}</td>
-        <td>
-          <a href="{{ url_for('admin_memory.view_entry', entry_id=entry._id) }}" class="btn">{{ t('Anzeigen') }}</a>
-        </td>
-      </tr>
-      {% else %}
-      <tr><td colspan="5">{{ t('Keine Speicherstände gefunden.') }}</td></tr>
-      {% endfor %}
-    </tbody>
-  </table>
+<h1 class="page-title">🧠 {{ t('Memory Viewer') }}</h1>
+<div style="margin-bottom:1rem; display:flex; gap:0.5rem; flex-wrap:wrap;">
+  <input id="search" type="text" placeholder="{{ t('Search') }}" style="flex:1; padding:0.5rem; border-radius:6px;">
+  <button id="reset" class="btn">{{ t('Reset') }}</button>
+  {% if session.get('user', {}).get('role_level') == 'ADMIN' %}
+  <form method="post" action="{{ url_for('admin_memory.clear_memory') }}">
+    <button class="btn btn-glow" type="submit">🗑 {{ t('Cache löschen') }}</button>
+  </form>
+  {% endif %}
 </div>
+<table class="table" id="memory-table" style="width:100%;">
+  <thead>
+    <tr>
+      <th>{{ t('Key') }}</th>
+      <th>{{ t('Value') }}</th>
+      <th>{{ t('Source') }}</th>
+      <th>{{ t('Created At') }}</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for entry in memory_entries %}
+    <tr class="source-{{ entry.source }}">
+      <td>{{ entry.key }}</td>
+      <td title="{{ entry.value }}">{{ entry.value | string | truncate(60) }}</td>
+      <td>{{ entry.source }}</td>
+      <td>{{ entry.created_at or '–' }}</td>
+    </tr>
+    {% else %}
+    <tr><td colspan="4">{{ t('Keine Speicherstände gefunden.') }}</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+<script>
+(function() {
+  const search = document.getElementById('search');
+  const reset = document.getElementById('reset');
+  const rows = Array.from(document.querySelectorAll('#memory-table tbody tr'));
+  function filter() {
+    const q = search.value.toLowerCase();
+    rows.forEach(r => {
+      r.style.display = r.innerText.toLowerCase().includes(q) ? '' : 'none';
+    });
+  }
+  search.addEventListener('input', filter);
+  reset.addEventListener('click', () => { search.value=''; filter(); });
+  document.querySelectorAll('#memory-table th').forEach((th, idx) => {
+    th.style.cursor = 'pointer';
+    th.addEventListener('click', () => {
+      const sorted = rows.sort((a,b) => a.children[idx].innerText.localeCompare(b.children[idx].innerText));
+      const tbody = document.querySelector('#memory-table tbody');
+      sorted.forEach(r => tbody.appendChild(r));
+    });
+  });
+})();
+</script>
 {% endblock %}
-

--- a/web/admin/memory_routes.py
+++ b/web/admin/memory_routes.py
@@ -4,12 +4,48 @@
 
 import bleach
 from bson import ObjectId
-from flask import Blueprint, abort, render_template
+from flask import Blueprint, abort, flash, redirect, render_template, session, url_for
 from markdown import markdown
 from markupsafe import Markup
 
 from mongo_service import get_collection
 from web.auth.decorators import admin_required
+
+
+def get_memory_entries() -> list[dict]:
+    """Collect memory entries from various sources."""
+    entries: list[dict] = []
+
+    # MongoDB stored contexts
+    collection = get_collection("memory_contexts")
+    try:
+        for doc in collection.find().sort("exported_at", -1):
+            entries.append(
+                {
+                    "key": str(doc.get("_id")),
+                    "value": doc.get("content") or doc.get("description"),
+                    "created_at": doc.get("exported_at") or doc.get("created_at"),
+                    "source": "mongo",
+                }
+            )
+    except Exception:
+        pass
+
+    # Example: in-memory session values (for current admin only)
+    for k, v in session.items():
+        if k == "_flashes":
+            continue
+        entries.append(
+            {
+                "key": k,
+                "value": v,
+                "created_at": None,
+                "source": "session",
+            }
+        )
+
+    return entries
+
 
 admin_memory = Blueprint("admin_memory", __name__, url_prefix="/admin/memory")
 
@@ -17,9 +53,7 @@ admin_memory = Blueprint("admin_memory", __name__, url_prefix="/admin/memory")
 @admin_memory.route("/")
 @admin_required
 def index():
-    collection = get_collection("memory_contexts")
-    collection.create_index("exported_at")
-    entries = list(collection.find().sort("exported_at", -1))
+    entries = get_memory_entries()
     return render_template("admin/memory/index.html", memory_entries=entries)
 
 
@@ -37,3 +71,13 @@ def view_entry(entry_id: str):
         content_html = Markup(bleach.clean(markdown(content_md)))
 
     return render_template("admin/memory/detail.html", entry=entry, content_html=content_html)
+
+
+@admin_memory.route("/clear", methods=["POST"])
+@admin_required
+def clear_memory():
+    """Delete all stored memory contexts."""
+    collection = get_collection("memory_contexts")
+    collection.delete_many({})
+    flash("Cache wurde geleert.", "success")
+    return redirect(url_for("admin_memory.index"))


### PR DESCRIPTION
## Summary
- implement `get_memory_entries` helper in `web/admin/memory_routes.py`
- show memory entries in `templates/admin/memory/index.html`
- enable clearing memory store
- add minimal table styling in `static/css/style.css`

## Testing
- `flake8 web/admin/memory_routes.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861f6df815c8324b917a08078bc42e5