### PR TITLE
Fix OAuth token path for Railway

### DIFF
--- a/config.py
+++ b/config.py
@@ -67,7 +67,7 @@ class Config:
     GOOGLE_CREDENTIALS_FILE: str | None = get_env_str(
         "GOOGLE_CREDENTIALS_FILE",
         required=False,
-        default=os.path.join(basedir, "credentials", "oauth_client.json"),
+        default="/data/google_token.json",
     )
     GOOGLE_CALENDAR_SCOPES: list[str] = get_env_str(
         "GOOGLE_CALENDAR_SCOPES",

--- a/google_calendar_sync.py
+++ b/google_calendar_sync.py
@@ -21,7 +21,7 @@ logger.addHandler(handler)
 logger.setLevel(logging.INFO)
 
 # Token path
-TOKEN_PATH = Path("token/token.json")
+TOKEN_PATH = Path("/data/google_token.json")
 
 
 def load_credentials() -> Optional[Credentials]:

--- a/google_oauth_web.py
+++ b/google_oauth_web.py
@@ -8,7 +8,7 @@ from google_auth_oauthlib.flow import Flow
 SCOPES = ["https://www.googleapis.com/auth/calendar"]
 REDIRECT_URI = "https://fur-martix.up.railway.app/oauth2callback"
 CLIENT_SECRETS_FILE = Path("credentials/client_secret.json")
-TOKEN_PATH = Path("token/token.json")
+TOKEN_PATH = Path("/data/google_token.json")
 
 app = Flask(__name__)
 app.secret_key = os.environ.get("SECRET_KEY", "change-me")
@@ -41,7 +41,6 @@ def oauth2callback() -> str:
     )
     flow.fetch_token(authorization_response=request.url)
     creds = flow.credentials
-    TOKEN_PATH.parent.mkdir(exist_ok=True)
     TOKEN_PATH.write_text(creds.to_json())
     return "Authentication successful"
 

--- a/web/routes/google_oauth_web.py
+++ b/web/routes/google_oauth_web.py
@@ -15,7 +15,7 @@ oauth_bp = Blueprint("oauth_web", __name__)
 # Constants
 SCOPES = ["https://www.googleapis.com/auth/calendar"]
 CLIENT_SECRET_FILE = Path("credentials/client_secret.json")
-TOKEN_PATH = Path("token/token.json")
+TOKEN_PATH = Path("/data/google_token.json")
 REDIRECT_URI = "https://fur-martix.up.railway.app/oauth2callback"
 
 # Logger setup
@@ -25,6 +25,7 @@ log = logging.getLogger(__name__)
 state_map: dict[str, float] = {}
 
 # ---- Routes ----
+
 
 @oauth_bp.route("/auth/initiate")
 def auth_initiate() -> Response:
@@ -80,7 +81,6 @@ def oauth2callback() -> Response:
 
     creds = flow.credentials
     try:
-        TOKEN_PATH.parent.mkdir(parents=True, exist_ok=True)
         TOKEN_PATH.write_text(creds.to_json())
         log.info("Token successfully saved to %s", TOKEN_PATH)
     except Exception:
@@ -91,6 +91,7 @@ def oauth2callback() -> Response:
 
 
 # ---- Helpers ----
+
 
 def load_credentials() -> Optional[Credentials]:
     """Load stored credentials from token file."""


### PR DESCRIPTION
## Summary
- store Google OAuth tokens in `/data` instead of project folder
- update oauth blueprint and helper script to use the persistent token path
- adjust config default path for credentials

## Testing
- `black . --quiet`
- `isort . --quiet`
- `flake8` *(fails: F401 unused imports)*
- `pytest --disable-warnings --maxfail=1 -q`

------
https://chatgpt.com/codex/tasks/task_e_68621bb0ea0c832490b5c83f3feeff45