### PR TITLE
Add admin pet advisor page

### DIFF
--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -13,6 +13,7 @@ from flask import (
     redirect,
     render_template,
     request,
+    session,
     url_for,
 )
 from werkzeug.utils import secure_filename
@@ -418,3 +419,13 @@ def upload():
         files = sorted(f for f in os.listdir(upload_folder) if _allowed_file(f))
 
     return render_template("admin/upload.html", files=files)
+
+
+@admin.route("/pet-advisor")
+def pet_advisor():
+    """Show the pet advisor dashboard for admins and R4 roles."""
+    user = session.get("user")
+    roles = session.get("discord_roles", [])
+    if not user or (user.get("role_level") != "ADMIN" and "R4" not in roles):
+        return "403 - Zugriff verweigert", 403
+    return render_template("admin/pet_advisor.html")

--- a/templates/admin/pet_advisor.html
+++ b/templates/admin/pet_advisor.html
@@ -1,0 +1,11 @@
+{% extends "admin/admin_base.html" %}
+{% set bg_image = "/static/bg/admin.png" %}
+{% block title %}Pet Advisor{% endblock %}
+
+{% block content %}
+  <div id="pet-advisor-root"></div>
+{% endblock %}
+
+{% block scripts %}
+  <script type="module" src="{{ url_for('static', filename='js/pet_advisor.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `/pet-advisor` route in `blueprints/admin.py`
- serve new template `admin/pet_advisor.html`

## Testing
- `black --check .`
- `flake8`
- `pytest -q` *(fails: missing dependencies such as motor and google-auth-oauthlib)*

------
https://chatgpt.com/codex/tasks/task_e_68632103008c8324952582270b061ec2