### PR TITLE
Fix PetAdvisor route for admin

### DIFF
--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -93,11 +93,12 @@ def downloads():
 
 @require_roles(["R4", "ADMIN"])
 @r4_required
-@admin.route("/pet_advisor")
+@admin.route("/pet-advisor")
 def pet_advisor():
+    """Render the Pet Advisor dashboard for authorized users."""
     if current_app.config.get("TESTING"):
         return "petadvisor"
-    return render_template("admin/PetAdvisorDashboard.tsx")
+    return render_template("admin/pet_advisor.html")
 
 
 @require_roles(["R4", "ADMIN"])
@@ -428,13 +429,3 @@ def upload():
         files = sorted(f for f in os.listdir(upload_folder) if _allowed_file(f))
 
     return render_template("admin/upload.html", files=files)
-
-
-@admin.route("/pet-advisor")
-def pet_advisor():
-    """Show the pet advisor dashboard for admins and R4 roles."""
-    user = session.get("user")
-    roles = session.get("discord_roles", [])
-    if not user or (user.get("role_level") != "ADMIN" and "R4" not in roles):
-        return "403 - Zugriff verweigert", 403
-    return render_template("admin/pet_advisor.html")

--- a/tests/test_nav_rendering.py
+++ b/tests/test_nav_rendering.py
@@ -21,7 +21,7 @@ def test_nav_guest_hidden(client):
     assert "/admin/dashboard" not in html
     assert "/members/dashboard" not in html
     assert "/admin/upload" not in html
-    assert "/admin/pet_advisor" not in html
+    assert "/admin/pet-advisor" not in html
     assert "/admin/memory" not in html
 
 
@@ -32,7 +32,7 @@ def test_nav_r3_sees_member_only(client):
     assert "/members/dashboard" in html
     assert "/admin/dashboard" not in html
     assert "/admin/upload" not in html
-    assert "/admin/pet_advisor" not in html
+    assert "/admin/pet-advisor" not in html
     assert "/admin/memory" not in html
 
 
@@ -43,7 +43,7 @@ def test_nav_r4_sees_admin(client):
     assert "/members/dashboard" in html
     assert "/admin/dashboard" in html
     assert "/admin/upload" in html
-    assert "/admin/pet_advisor" in html
+    assert "/admin/pet-advisor" in html
     assert "/admin/memory" not in html
 
 
@@ -54,5 +54,5 @@ def test_nav_admin_sees_all(client):
     assert "/members/dashboard" in html
     assert "/admin/dashboard" in html
     assert "/admin/upload" in html
-    assert "/admin/pet_advisor" in html
+    assert "/admin/pet-advisor" in html
     assert "/admin/memory" in html


### PR DESCRIPTION
## Summary
- repair admin route for Pet Advisor dashboard
- ensure nav rendering tests look for `/admin/pet-advisor`

## Testing
- `black --check .`
- `flake8`
- `env MONGODB_URI='mongodb://localhost:27017/testdb' pytest tests/test_nav_rendering.py -q`
- `env MONGODB_URI='mongodb://localhost:27017/testdb' pytest -q` *(fails: test_calendar_service.py::test_sync_stores_events_and_token, test_event_crud.py::test_create_and_fetch_by_id, test_google_sync.py::test_sync_to_mongodb, test_google_sync.py::test_all_day_event)*

------
https://chatgpt.com/codex/tasks/task_e_6863440d182c8324a1c4507440507021