### PR TITLE
Fix PetAdvisor React rendering

### DIFF
--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -93,11 +93,12 @@ def downloads():
 
 @require_roles(["R4", "ADMIN"])
 @r4_required
-@admin.route("/pet_advisor")
+@admin.route("/pet-advisor")
 def pet_advisor():
+    """Render the Pet Advisor dashboard for authorized users."""
     if current_app.config.get("TESTING"):
         return "petadvisor"
-    return render_template("admin/PetAdvisorDashboard.tsx")
+    return render_template("admin/pet_advisor.html")
 
 
 @require_roles(["R4", "ADMIN"])
@@ -428,13 +429,3 @@ def upload():
         files = sorted(f for f in os.listdir(upload_folder) if _allowed_file(f))
 
     return render_template("admin/upload.html", files=files)
-
-
-@admin.route("/pet-advisor")
-def pet_advisor():
-    """Show the pet advisor dashboard for admins and R4 roles."""
-    user = session.get("user")
-    roles = session.get("discord_roles", [])
-    if not user or (user.get("role_level") != "ADMIN" and "R4" not in roles):
-        return "403 - Zugriff verweigert", 403
-    return render_template("admin/pet_advisor.html")

--- a/static/js/pet_advisor.js
+++ b/static/js/pet_advisor.js
@@ -1,0 +1,88 @@
+const pets = [
+  {
+    name: "Wolf",
+    role: "Main",
+    description: "DPS + Kontrolle",
+    skills: ["Phantom Klinge", "Flammenling", "Geist Flamme", "Zorn Ling", "Riss Leere"],
+    optional: ["Blitzsiegel"],
+    tags: ["DPS", "Silence", "Anti-Passiv"]
+  },
+  {
+    name: "Misha",
+    role: "Tank",
+    description: "Überleben + Sustain",
+    skills: ["Wut Leitfaden", "Aufräumen Feder", "Phantom Schild", "Äther. Verteid.", "Wächtergeist"],
+    optional: ["Geistwind"],
+    tags: ["DEF", "Heilung", "Zorn"]
+  },
+  {
+    name: "Rottweiler",
+    role: "Support",
+    description: "Kontrolle + Verstärkung",
+    skills: ["Blitzsiegel", "Riss Leere", "Zorn Ling", "Wächtergeist", "Geist Flamme"],
+    optional: ["Flammenling"],
+    tags: ["Anti-Zorn", "Silence", "Buff"]
+  }
+];
+
+function PetAdvisorDashboard() {
+  const [selectedRole, setSelectedRole] = React.useState("All");
+  const filteredPets =
+    selectedRole === "All"
+      ? pets
+      : pets.filter((p) => p.role.toLowerCase() === selectedRole.toLowerCase());
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">🐾 Pet Advisor Dashboard</h1>
+      <div className="flex gap-2">
+        {['All', 'Main', 'Tank', 'Support'].map((r) => (
+          <button
+            key={r}
+            onClick={() => setSelectedRole(r)}
+            className={
+              'px-2 py-1 rounded ' +
+              (selectedRole === r ? 'bg-orange-500 text-white' : 'bg-gray-700')
+            }
+          >
+            {r}
+          </button>
+        ))}
+      </div>
+      <div className="grid md:grid-cols-3 gap-4">
+        {filteredPets.map((pet) => (
+          <div key={pet.name} className="rounded-2xl shadow p-4 space-y-2 bg-gray-800">
+            <div className="text-xl font-semibold">{pet.name}</div>
+            <div className="text-sm opacity-80">{pet.description}</div>
+            <div className="space-y-1">
+              <div className="font-medium">Empfohlene Skills:</div>
+              <ul className="list-disc list-inside text-sm">
+                {pet.skills.map((skill) => (
+                  <li key={skill}>{skill}</li>
+                ))}
+              </ul>
+              <div className="text-xs italic">Optional: {pet.optional.join(', ')}</div>
+            </div>
+            <div className="flex flex-wrap gap-1 pt-2">
+              {pet.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="bg-gray-600 rounded px-2 py-0.5 text-xs"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const rootEl = document.getElementById('pet-advisor-root');
+  if (!rootEl) return;
+  const root = ReactDOM.createRoot(rootEl);
+  root.render(<PetAdvisorDashboard />);
+});

--- a/templates/admin/pet_advisor.html
+++ b/templates/admin/pet_advisor.html
@@ -7,5 +7,8 @@
 {% endblock %}
 
 {% block scripts %}
-  <script type="module" src="{{ url_for('static', filename='js/pet_advisor.js') }}"></script>
+  <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script type="text/babel" src="{{ url_for('static', filename='js/pet_advisor.js') }}"></script>
 {% endblock %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import os
+from flask import session
 
 import pytest
 
@@ -88,6 +89,11 @@ def app():
     @public.route("/events")
     def events():
         return "events"
+
+    @public.route("/logout")
+    def logout():
+        session.clear()
+        return "logout"
 
     @public.route("/leaderboard")
     def leaderboard():

--- a/tests/test_nav_rendering.py
+++ b/tests/test_nav_rendering.py
@@ -21,7 +21,7 @@ def test_nav_guest_hidden(client):
     assert "/admin/dashboard" not in html
     assert "/members/dashboard" not in html
     assert "/admin/upload" not in html
-    assert "/admin/pet_advisor" not in html
+    assert "/admin/pet-advisor" not in html
     assert "/admin/memory" not in html
 
 
@@ -32,7 +32,7 @@ def test_nav_r3_sees_member_only(client):
     assert "/members/dashboard" in html
     assert "/admin/dashboard" not in html
     assert "/admin/upload" not in html
-    assert "/admin/pet_advisor" not in html
+    assert "/admin/pet-advisor" not in html
     assert "/admin/memory" not in html
 
 
@@ -43,7 +43,7 @@ def test_nav_r4_sees_admin(client):
     assert "/members/dashboard" in html
     assert "/admin/dashboard" in html
     assert "/admin/upload" in html
-    assert "/admin/pet_advisor" in html
+    assert "/admin/pet-advisor" in html
     assert "/admin/memory" not in html
 
 
@@ -54,5 +54,5 @@ def test_nav_admin_sees_all(client):
     assert "/members/dashboard" in html
     assert "/admin/dashboard" in html
     assert "/admin/upload" in html
-    assert "/admin/pet_advisor" in html
+    assert "/admin/pet-advisor" in html
     assert "/admin/memory" in html


### PR DESCRIPTION
## Summary
- load React-based PetAdvisor dashboard
- mount PetAdvisorDashboard via Babel script
- extend test fixtures with logout helper

## Testing
- `black --check .`
- `flake8`
- `env MONGODB_URI='mongodb://localhost:27017/testdb' pytest tests/test_nav_rendering.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6863440d182c8324a1c4507440507021