### PR TITLE
Improve calendar service initialization

### DIFF
--- a/tests/test_calendar_service.py
+++ b/tests/test_calendar_service.py
@@ -44,6 +44,7 @@ async def test_sync_stores_events_and_token(monkeypatch):
     service = mod.CalendarService(
         calendar_id="c1", events_collection=events_col, tokens_collection=tokens_col
     )
+    monkeypatch.setattr(service, "_build_service", lambda: setattr(service, "service", object()))
 
     async def fake_api(params):
         return {
@@ -73,6 +74,7 @@ async def test_sync_resync_on_410(monkeypatch):
     service = mod.CalendarService(
         calendar_id="c1", events_collection=events_col, tokens_collection=tokens_col
     )
+    monkeypatch.setattr(service, "_build_service", lambda: setattr(service, "service", object()))
 
     calls = {"n": 0}
 
@@ -100,6 +102,7 @@ async def test_sync_uses_stored_token(monkeypatch):
     service = mod.CalendarService(
         calendar_id="c1", events_collection=events_col, tokens_collection=tokens_col
     )
+    monkeypatch.setattr(service, "_build_service", lambda: setattr(service, "service", object()))
 
     captured = {}
 


### PR DESCRIPTION
## Summary
- store Google API service on instance to avoid repeated builds
- handle missing credentials and service initialization gracefully
- adjust calendar service tests to patch new `_build_service`

## Testing
- `black --check services/calendar_service.py tests/test_calendar_service.py`
- `flake8` *(fails: F401 'flask.session' imported but unused)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68643692afcc8324be65de2ba03f5333