### PR TITLE
Use env var for Google token path

### DIFF
--- a/google_calendar_sync.py
+++ b/google_calendar_sync.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Optional
@@ -22,7 +23,7 @@ logger.addHandler(handler)
 logger.setLevel(logging.INFO)
 
 # Token path
-TOKEN_PATH = Path("/data/google_token.json")
+TOKEN_PATH = Path(os.getenv("GOOGLE_CREDENTIALS_FILE", "/data/google_token.json"))
 
 
 def _get_token_collection():

--- a/web/routes/google_oauth_web.py
+++ b/web/routes/google_oauth_web.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import time
 from pathlib import Path
 from typing import Optional
@@ -15,7 +16,7 @@ oauth_bp = Blueprint("oauth_web", __name__)
 # Constants
 SCOPES = ["https://www.googleapis.com/auth/calendar"]
 CLIENT_SECRET_FILE = Path("credentials/client_secret.json")
-TOKEN_PATH = Path("/data/google_token.json")
+TOKEN_PATH = Path(os.getenv("GOOGLE_CREDENTIALS_FILE", "/data/google_token.json"))
 REDIRECT_URI = "https://fur-martix.up.railway.app/oauth2callback"
 
 # Logger setup


### PR DESCRIPTION
## Summary
- keep credentials path configurable via `GOOGLE_CREDENTIALS_FILE`

## Testing
- `black --check google_calendar_sync.py web/routes/google_oauth_web.py`
- `flake8 google_calendar_sync.py web/routes/google_oauth_web.py`
- `pytest -q tests/test_google_sync.py::test_sync_to_mongodb -q` *(fails: GOOGLE_CALENDAR_ID not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68645aedc69483248fa2c1c509d1fb8b