### PR TITLE
Load Google OAuth paths from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,8 @@ GOOGLE_SYNC_INTERVAL_MINUTES=2         # Sync interval
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 GOOGLE_REDIRECT_URI=http://localhost:8080/oauth/google/callback
-GOOGLE_CREDENTIALS_FILE=credentials/oauth_client.json
+GOOGLE_CLIENT_CONFIG=credentials/client_secret.json  # Path to OAuth client config
+GOOGLE_CREDENTIALS_FILE=/data/google_token.json       # Token storage path
 GOOGLE_CALENDAR_SCOPES=https://www.googleapis.com/auth/calendar.readonly
 
 # Poster and web

--- a/google_oauth_web.py
+++ b/google_oauth_web.py
@@ -21,7 +21,7 @@ from google_auth_oauthlib.flow import Flow
 log = logging.getLogger(__name__)
 
 # OAuth configuration loaded from environment so the same code works locally
-# and on Railway.  ``GOOGLE_TOKEN_PATH`` points to ``/data`` which should be
+# and on Railway.  ``GOOGLE_CREDENTIALS_FILE`` points to ``/data`` which should be
 # backed by a volume in production.
 SCOPES = os.getenv(
     "GOOGLE_CALENDAR_SCOPES",
@@ -29,7 +29,7 @@ SCOPES = os.getenv(
 ).split(",")
 REDIRECT_URI = os.getenv("GOOGLE_REDIRECT_URI", "https://fur-martix.up.railway.app/oauth2callback")
 CLIENT_SECRETS_FILE = Path(os.getenv("GOOGLE_CLIENT_CONFIG", "credentials/client_secret.json"))
-TOKEN_PATH = Path(os.getenv("GOOGLE_TOKEN_PATH", "/data/google_token.json"))
+TOKEN_PATH = Path(os.getenv("GOOGLE_CREDENTIALS_FILE", "/data/google_token.json"))
 # Using a JSON file avoids pickle security issues and works across container
 # restarts. In production consider storing this JSON in MongoDB instead of the
 # ephemeral filesystem.

--- a/web/routes/google_oauth_web.py
+++ b/web/routes/google_oauth_web.py
@@ -15,7 +15,7 @@ oauth_bp = Blueprint("oauth_web", __name__)
 
 # Constants
 SCOPES = ["https://www.googleapis.com/auth/calendar"]
-CLIENT_SECRET_FILE = Path("credentials/client_secret.json")
+CLIENT_SECRET_FILE = Path(os.getenv("GOOGLE_CLIENT_CONFIG", "credentials/client_secret.json"))
 TOKEN_PATH = Path(os.getenv("GOOGLE_CREDENTIALS_FILE", "/data/google_token.json"))
 REDIRECT_URI = "https://fur-martix.up.railway.app/oauth2callback"
 


### PR DESCRIPTION
## Summary
- read Google OAuth token/config paths via environment variables
- document `GOOGLE_CLIENT_CONFIG` and clarify `GOOGLE_CREDENTIALS_FILE`

## Testing
- `black --check .`
- `flake8` *(fails: admin.py F401 'flask.session' imported but unused)*
- `pytest -q` *(fails: test suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_686462a5f41483248135aec6984cd2d6