### PR TITLE
Rename google_event_id field

### DIFF
--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -13,7 +13,6 @@ from flask import (
     redirect,
     render_template,
     request,
-    session,
     url_for,
 )
 from werkzeug.utils import secure_filename

--- a/bot/cogs/reminder_autopilot.py
+++ b/bot/cogs/reminder_autopilot.py
@@ -95,7 +95,7 @@ class ReminderAutopilot(commands.Cog):
             )
             mapped_events = []
             for ev in events:
-                doc = get_collection("events").find_one({"google_event_id": ev.get("id")})
+                doc = get_collection("events").find_one({"google_id": ev.get("id")})
                 if doc:
                     doc.update(ev)
                     mapped_events.append(doc)

--- a/google_calendar_sync.py
+++ b/google_calendar_sync.py
@@ -137,7 +137,7 @@ def _build_doc(event: dict) -> dict:
     start_dt = _parse_datetime(event.get("start"))
     end_dt = _parse_datetime(event.get("end"))
     return {
-        "google_event_id": event.get("id"),
+        "google_id": event.get("id"),
         "title": event.get("summary", "No Title"),
         "description": event.get("description"),
         "location": event.get("location"),
@@ -192,13 +192,13 @@ def sync_to_mongodb(collection: str = "calendar_events") -> int:
     count = 0
     for ev in events:
         doc = _build_doc(ev)
-        if not doc["google_event_id"]:
+        if not doc["google_id"]:
             continue
         try:
-            col.update_one({"google_event_id": doc["google_event_id"]}, {"$set": doc}, upsert=True)
+            col.update_one({"google_id": doc["google_id"]}, {"$set": doc}, upsert=True)
             count += 1
         except Exception:
-            logger.exception("Failed to sync event %s", doc.get("google_event_id"))
+            logger.exception("Failed to sync event %s", doc.get("google_id"))
     new_token = data.get("nextSyncToken")
     if new_token:
         _store_sync_token(new_token)

--- a/tests/test_google_sync.py
+++ b/tests/test_google_sync.py
@@ -8,7 +8,7 @@ class DummyCollection:
         self.docs = {}
 
     def update_one(self, flt, update, upsert=False):
-        self.docs[flt["google_event_id"]] = update["$set"]
+        self.docs[flt["google_id"]] = update["$set"]
 
 
 def test_sync_to_mongodb(monkeypatch):

--- a/tests/test_reminder_timings.py
+++ b/tests/test_reminder_timings.py
@@ -55,7 +55,7 @@ def test_autopilot_sends_with_role_mention(monkeypatch):
         "_id": 1,
         "title": "Ping",
         "event_time": now + timedelta(minutes=10, seconds=1),
-        "google_event_id": "g1",
+        "google_id": "g1",
     }
     monkeypatch.setattr(autopilot_mod, "datetime", types.SimpleNamespace(utcnow=lambda: now))
     events_col = DummyCollection([event])


### PR DESCRIPTION
## Summary
- switch google_event_id to google_id across sync helpers and tests
- remove unused session import in admin blueprint

## Testing
- `black --check .`
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bleach')*

------
https://chatgpt.com/codex/tasks/task_e_68646678ce988324b1627f7d01ccbec4