### PR TITLE
Update OAuth token docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ cp .env.example .env
 # Die Google OAuth Client-Konfiguration (`client_secret.json`) sollte **nicht**
 # im Repository liegen. Speichere den Pfad stattdessen in der ENV-Variable
 # `GOOGLE_CLIENT_CONFIG` oder mounte die Datei als Volume (z. B. `/data/client_secret.json`).
+# OAuth-Tokens werden als JSON-Datei unter dem Pfad aus `GOOGLE_CREDENTIALS_FILE`
+# gespeichert (Standard: `/data/google_token.json`).
 
 # 4. Datenbank vorbereiten
 python init_db_core.py
@@ -146,7 +148,8 @@ Pull Request mit Beschreibung & Verweis auf Issues
 🐞 Bekannte Probleme
 🌐 Einige Übersetzungsdateien (translations/*.json) sind inkonsistent → i18n_tools/translate_sync.py verwenden
 
-🔐 token.pickle muss lokal erzeugt sein für GCal OAuth
+🔐 OAuth-Tokens werden beim ersten Durchlauf automatisch als JSON gespeichert.
+Setze `GOOGLE_CREDENTIALS_FILE` auf den gewünschten Pfad.
 
 🧪 Einige Tests benötigen mongomock – ggf. separat installieren
 

--- a/google_oauth_setup.py
+++ b/google_oauth_setup.py
@@ -1,31 +1,33 @@
 import os
-import pickle
 from pathlib import Path
 
 from google.auth.transport.requests import Request
 from google_auth_oauthlib.flow import InstalledAppFlow
+from google.oauth2.credentials import Credentials
 
 SCOPES = ["https://www.googleapis.com/auth/calendar"]
 
 
 def main() -> None:
-    """Run OAuth flow and store token."""
-    os.makedirs("token", exist_ok=True)
-    token_path = Path("token/token.pickle")
+    """Run OAuth flow and store token as JSON."""
+    token_path = Path(os.getenv("GOOGLE_CREDENTIALS_FILE", "/data/google_token.json"))
     creds = None
     if token_path.exists():
-        with token_path.open("rb") as fh:
-            creds = pickle.load(fh)
+        try:
+            creds = Credentials.from_authorized_user_file(token_path, SCOPES)
+        except Exception:  # noqa: BLE001
+            creds = None
     if not creds or not creds.valid:
         if creds and creds.expired and creds.refresh_token:
             creds.refresh(Request())
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
-                "credentials/client_secret.json", SCOPES
+                os.getenv("GOOGLE_CLIENT_CONFIG", "credentials/client_secret.json"),
+                SCOPES,
             )
             creds = flow.run_local_server(port=0)
-        with token_path.open("wb") as fh:
-            pickle.dump(creds, fh)
+        token_path.parent.mkdir(parents=True, exist_ok=True)
+        token_path.write_text(creds.to_json())
     print(f"Token saved to {token_path}")
 
 


### PR DESCRIPTION
## Summary
- document that OAuth tokens are saved as JSON in `GOOGLE_CREDENTIALS_FILE`
- describe env variable setup in README
- remove pickle usage from helper scripts

## Testing
- `black --check .`
- `flake8`
- `pytest` *(fails: tests/test_calendar_service.py::test_sync_stores_events_and_token, tests/test_event_crud.py::test_create_and_fetch_by_id, tests/test_google_sync.py::test_sync_to_mongodb, tests/test_google_sync.py::test_all_day_event)*

------
https://chatgpt.com/codex/tasks/task_e_686476a3ae7083249c9da6e1bb373f65