### PR TITLE
Update OAuth config handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ pip install -r requirements.txt
 # 3. ENV-Variablen setzen (.env)
 cp .env.example .env
 # → Trage hier deine MongoDB URI, Google OAuth & Discord Token ein
-# Die Google OAuth Client-Konfiguration (`client_secret.json`) sollte **nicht**
-# im Repository liegen. Speichere den Pfad stattdessen in der ENV-Variable
-# `GOOGLE_CLIENT_CONFIG` oder mounte die Datei als Volume (z. B. `/data/client_secret.json`).
-# OAuth-Tokens werden als JSON-Datei unter dem Pfad aus `GOOGLE_CREDENTIALS_FILE`
-# gespeichert (Standard: `/data/google_token.json`).
+# Die Google OAuth Client-Konfiguration (`client_secret.json`) darf **nicht** im
+# Repository liegen. Hinterlege den Pfad in der ENV-Variable
+# `GOOGLE_CLIENT_CONFIG` (kein Fallback). OAuth-Tokens werden per
+# `creds.to_json()` unter `GOOGLE_CREDENTIALS_FILE` gespeichert (Standard:
+# `/data/google_token.json`).
 
 # 4. Datenbank vorbereiten
 python init_db_core.py

--- a/google_oauth_setup.py
+++ b/google_oauth_setup.py
@@ -22,7 +22,7 @@ def main() -> None:
             creds.refresh(Request())
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
-                os.getenv("GOOGLE_CLIENT_CONFIG", "credentials/client_secret.json"),
+                os.getenv("GOOGLE_CLIENT_CONFIG"),
                 SCOPES,
             )
             creds = flow.run_local_server(port=0)

--- a/google_oauth_web.py
+++ b/google_oauth_web.py
@@ -28,7 +28,7 @@ SCOPES = os.getenv(
     "https://www.googleapis.com/auth/calendar",
 ).split(",")
 REDIRECT_URI = os.getenv("GOOGLE_REDIRECT_URI", "https://fur-martix.up.railway.app/oauth2callback")
-CLIENT_SECRETS_FILE = Path(os.getenv("GOOGLE_CLIENT_CONFIG", "credentials/client_secret.json"))
+CLIENT_SECRETS_FILE = Path(os.getenv("GOOGLE_CLIENT_CONFIG"))
 TOKEN_PATH = Path(os.getenv("GOOGLE_CREDENTIALS_FILE", "/data/google_token.json"))
 # Using a JSON file avoids pickle security issues and works across container
 # restarts. In production consider storing this JSON in MongoDB instead of the

--- a/web/routes/google_oauth_web.py
+++ b/web/routes/google_oauth_web.py
@@ -15,7 +15,7 @@ oauth_bp = Blueprint("oauth_web", __name__)
 
 # Constants
 SCOPES = ["https://www.googleapis.com/auth/calendar"]
-CLIENT_SECRET_FILE = Path(os.getenv("GOOGLE_CLIENT_CONFIG", "credentials/client_secret.json"))
+CLIENT_SECRET_FILE = Path(os.getenv("GOOGLE_CLIENT_CONFIG"))
 TOKEN_PATH = Path(os.getenv("GOOGLE_CREDENTIALS_FILE", "/data/google_token.json"))
 REDIRECT_URI = "https://fur-martix.up.railway.app/oauth2callback"
 


### PR DESCRIPTION
## Summary
- read OAuth config path from `GOOGLE_CLIENT_CONFIG` environment variable
- describe OAuth env vars in README

## Testing
- `black --check google_oauth_web.py web/routes/google_oauth_web.py google_oauth_setup.py`
- `flake8 google_oauth_web.py web/routes/google_oauth_web.py google_oauth_setup.py`
- `pytest -q` *(fails: test_sync_stores_events_and_token, test_create_and_fetch_by_id, test_google_login_flow, test_oauth2callback_invalid_state, test_oauth2callback_success, test_oauth2callback_invalid_state_or_token, test_sync_to_mongodb, test_all_day_event)*

------
https://chatgpt.com/codex/tasks/task_e_6864836c4a14832490a28152e03b574d