### PR TITLE
Add logging to utilities and scripts

### DIFF
--- a/diagnostic_tool.py
+++ b/diagnostic_tool.py
@@ -6,9 +6,13 @@ import argparse
 from datetime import datetime
 from pathlib import Path
 from typing import Iterable
+import logging
 
 from config import Config
 from utils import event_helpers
+
+
+log = logging.getLogger(__name__)
 
 
 def get_recent_events() -> str:
@@ -66,20 +70,20 @@ def main(argv: Iterable[str] | None = None) -> None:
         return
 
     if args.events:
-        print("== Recent Events ==")
-        print(get_recent_events())
+        log.info("== Recent Events ==")
+        log.info(get_recent_events())
     if args.channels:
-        print("== Channel Mappings ==")
+        log.info("== Channel Mappings ==")
         for key, value in get_channel_mapping().items():
-            print(f"{key}: {value}")
+            log.info("%s: %s", key, value)
     if args.posters:
-        print("== Poster Files ==")
+        log.info("== Poster Files ==")
         for item in get_poster_files():
-            print(item)
+            log.info(item)
     if args.logs:
-        print("== Log Files ==")
+        log.info("== Log Files ==")
         for item in get_log_files():
-            print(item)
+            log.info(item)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution

--- a/i18n_tools/auto_fill.py
+++ b/i18n_tools/auto_fill.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from pathlib import Path
 from typing import Dict, Set
 
@@ -7,6 +8,9 @@ import requests
 TRANSLATIONS_DIR = Path("translations")
 BASE_LANG = "en"
 API_URL = "https://translate.argosopentech.com/translate"
+
+
+log = logging.getLogger(__name__)
 
 
 def load_all() -> Dict[str, Dict[str, str]]:
@@ -35,7 +39,7 @@ def translate(text: str, target: str) -> str:
         resp.raise_for_status()
         return resp.json()["translatedText"]
     except Exception as e:
-        print(f"Translation error [{target}]: {e}")
+        log.error("Translation error [%s]: %s", target, e)
         return text
 
 
@@ -50,7 +54,7 @@ def main() -> None:
         missing = [k for k in all_keys if k not in entries]
         if not missing:
             continue
-        print(f"{lang}: adding {len(missing)} translations")
+        log.info("%s: adding %s translations", lang, len(missing))
         for key in missing:
             source_text = base.get(key, key)
             entries[key] = translate(source_text, lang)

--- a/i18n_tools/cleanup_flags.py
+++ b/i18n_tools/cleanup_flags.py
@@ -1,5 +1,8 @@
 from pathlib import Path
 from typing import List
+import logging
+
+log = logging.getLogger(__name__)
 
 
 def cleanup_flags(
@@ -29,6 +32,6 @@ def cleanup_flags(
 if __name__ == "__main__":
     removed = cleanup_flags()
     if removed:
-        print(f"🧹 Removed {len(removed)} unused flags: {', '.join(removed)}")
+        log.info("🧹 Removed %s unused flags: %s", len(removed), ", ".join(removed))
     else:
-        print("✅ No unused flag icons found.")
+        log.info("✅ No unused flag icons found.")

--- a/i18n_tools/generate_key_list.py
+++ b/i18n_tools/generate_key_list.py
@@ -1,8 +1,12 @@
 import json
+import logging
 from pathlib import Path
 
 DEFAULT_SOURCE = Path("translations/en.json")
 DEFAULT_TARGET = Path("translation_keys.json")
+
+
+log = logging.getLogger(__name__)
 
 
 def update_key_list(source: Path = DEFAULT_SOURCE, target: Path = DEFAULT_TARGET) -> list[str]:
@@ -20,4 +24,4 @@ def update_key_list(source: Path = DEFAULT_SOURCE, target: Path = DEFAULT_TARGET
 
 if __name__ == "__main__":
     keys = update_key_list()
-    print(f"✅ Generated {len(keys)} translation keys.")
+    log.info("✅ Generated %s translation keys.", len(keys))

--- a/i18n_tools/translate_sync.py
+++ b/i18n_tools/translate_sync.py
@@ -10,6 +10,7 @@ import argparse
 import json
 import os
 import re
+import logging
 from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List
@@ -21,6 +22,8 @@ LANG_DIR = "i18n"
 MASTER_LANG = "de"
 REPORT_PATH = "untranslated_report.md"
 USE_GPT = True
+
+log = logging.getLogger(__name__)
 
 # 🌍 32 meistgesprochene Sprachen (ISO 639-1)
 TARGET_LANGS = [
@@ -122,7 +125,7 @@ def translate(text: str, lang: str) -> str:
         result = response.choices[0].message.content.strip()
         return restore_placeholders(result, placeholders)
     except Exception as e:
-        print(f"⚠️ GPT-Fehler ({lang}): {e}")
+        log.error("⚠️ GPT-Fehler (%s): %s", lang, e)
         return f"[{lang}] {text}"
 
 
@@ -142,7 +145,7 @@ def load_json(path: Path) -> Dict:
         with open(path, "r", encoding="utf-8") as f:
             return json.load(f)
     except json.JSONDecodeError:
-        print(f"❌ Ungültige JSON-Datei: {path}")
+        log.error("❌ Ungültige JSON-Datei: %s", path)
         return {}
 
 
@@ -226,13 +229,13 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    print("🌍 Starte Übersetzungsabgleich...")
+    log.info("🌍 Starte Übersetzungsabgleich...")
 
     result = sync_translations(dry_run=args.dry_run, report_only=args.report_only)
     generate_report(result)
 
-    print(f"✅ Fertig. Report: {REPORT_PATH}")
+    log.info("✅ Fertig. Report: %s", REPORT_PATH)
     if args.dry_run:
-        print("⚠️ Dry-Run: Keine Dateien wurden verändert.")
+        log.info("⚠️ Dry-Run: Keine Dateien wurden verändert.")
     elif args.report_only:
-        print("📄 Nur Report erstellt – Übersetzung übersprungen.")
+        log.info("📄 Nur Report erstellt – Übersetzung übersprungen.")

--- a/main_app.py
+++ b/main_app.py
@@ -88,7 +88,7 @@ def signal_handler(sig, frame):
 if __name__ == "__main__":
     try:
         init_db()
-        print("✅ Datenbank-Initialisierung erfolgreich.")
+        logging.info("✅ Datenbank-Initialisierung erfolgreich.")
 
         # 🧠 Agenten laden (Reminder, Translation, Champion etc.)
         agents = init_agents(db=db, session=session)
@@ -114,7 +114,7 @@ if __name__ == "__main__":
         app.run(host="0.0.0.0", port=port, debug=debug)
 
     except KeyboardInterrupt:
-        print("🛑 Manuell unterbrochen.")
+        logging.info("🛑 Manuell unterbrochen.")
     except Exception as e:
         log_error("Main", e)
         raise

--- a/mongo_test.py
+++ b/mongo_test.py
@@ -1,6 +1,7 @@
 # mongo_test.py
 
 import os
+import logging
 from pymongo import MongoClient
 from pymongo.server_api import ServerApi
 from dotenv import load_dotenv
@@ -16,10 +17,11 @@ if not uri:
 
 # MongoDB-Client erstellen
 client = MongoClient(uri, server_api=ServerApi("1"))
+log = logging.getLogger(__name__)
 
 # Verbindung testen
 try:
     client.admin.command("ping")
-    print("✅ Verbindung zu MongoDB Atlas erfolgreich!")
+    log.info("✅ Verbindung zu MongoDB Atlas erfolgreich!")
 except Exception as e:
-    print("❌ Verbindung fehlgeschlagen:", e)
+    log.error("❌ Verbindung fehlgeschlagen: %s", e)


### PR DESCRIPTION
## Summary
- use logging in MongoDB test helper and main app startup
- add log output for diagnostic tool
- introduce logging for i18n utility scripts

## Testing
- `flake8`
- `black --check .`
- `pytest -q` *(fails: ConfigurationError: The DNS query name does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_686496fc23ac8324a1a84913652f74a7