### PR TITLE
✅ Fix: add timeout and error handling for webhook

### DIFF
--- a/champion/webhook.py
+++ b/champion/webhook.py
@@ -1,16 +1,21 @@
 """Simple helper to send champion posters via Discord webhook."""
 
+import logging
 import requests
 
 from config import Config
 
 
-def send_discord_webhook(content: str, file_path: str) -> int:
+def send_discord_webhook(content: str, file_path: str) -> int | None:
     """Upload a file to the configured Discord webhook."""
 
     webhook_url = Config.DISCORD_WEBHOOK_URL
-    with open(file_path, "rb") as f:
-        files = {"file": f}
-        data = {"content": content}
-        response = requests.post(webhook_url, data=data, files=files)
-    return response.status_code
+    try:
+        with open(file_path, "rb") as f:
+            files = {"file": f}
+            data = {"content": content}
+            response = requests.post(webhook_url, data=data, files=files, timeout=10)
+        return response.status_code
+    except Exception as exc:  # noqa: BLE001
+        logging.error("Failed to send Discord webhook: %s", exc)
+        return None


### PR DESCRIPTION
## Summary
- add logging to champion webhook
- return `None` on failure
- add timeout for posting to Discord webhook

## Testing
- `black --check .`
- `flake8`
- `pytest -q` *(fails: AttributeError & test errors)*

------
https://chatgpt.com/codex/tasks/task_e_686498d626548324bd14997d1f629a7f