### PR TITLE
Fix test MongoDB URI

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,8 @@ import pytest
 from flask import session
 
 # environment for Flask app
-os.environ.setdefault("MONGODB_URI", "mongodb://localhost:27017/testdb")
+# Override the MongoDB URI for tests to avoid any external connections
+os.environ["MONGODB_URI"] = "mongodb://localhost:27017/testdb"
 os.environ.setdefault("DISCORD_TOKEN", "dummy")
 os.environ.setdefault("DISCORD_GUILD_ID", "1")
 os.environ.setdefault("REMINDER_CHANNEL_ID", "1")


### PR DESCRIPTION
## Summary
- override `MONGODB_URI` directly in `tests/conftest.py`

## Testing
- `black --check .`
- `flake8`
- `pytest -q` *(fails: test_calendar_service.py::test_sync_stores_events_and_token, test_champion_poster.py::test_generate_poster_and_webhook, test_event_crud.py::test_create_and_fetch_by_id, test_google_auth.py::test_google_login_flow, test_google_auth.py::test_oauth2callback_invalid_state, test_google_auth.py::test_oauth2callback_success, test_google_auth.py::test_oauth2callback_invalid_state_or_token, test_google_sync.py::test_sync_to_mongodb, test_google_sync.py::test_all_day_event)*

------
https://chatgpt.com/codex/tasks/task_e_6864bfd04fbc83248ef23c2e78336117