### PR TITLE
Add DM scheduler with daily and event reminders

### DIFF
--- a/bot/bot_main.py
+++ b/bot/bot_main.py
@@ -12,6 +12,7 @@ import aiohttp
 from config import Config
 
 from .translator import MyTranslator
+from .dm_scheduler import scheduler, schedule_dm_tasks
 
 # 🧠 Umschalten zwischen echtem Bot & Stub-Modus (z. B. für Web-Dashboard)
 USE_DISCORD_BOT = os.getenv("ENABLE_DISCORD_BOT", "false").lower() == "true"
@@ -51,6 +52,8 @@ async def create_bot() -> commands.Bot:
         @new_bot.event
         async def on_ready():
             log.info("✅ Eingeloggt als %s (ID: %s)", new_bot.user, new_bot.user.id)
+            if not scheduler.running:
+                schedule_dm_tasks(new_bot)
 
     else:
         new_bot = BotStub()

--- a/bot/dm_scheduler.py
+++ b/bot/dm_scheduler.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from pymongo.collection import Collection
+
+from mongo_service import get_collection
+
+log = logging.getLogger(__name__)
+
+scheduler = AsyncIOScheduler(timezone="UTC")
+
+
+def get_dm_users() -> list[int]:
+    """Return Discord user IDs that should receive DMs."""
+    users: Collection = get_collection("users")
+    return [int(u["discord_id"]) for u in users.find({"dm_enabled": True})]
+
+
+async def send_dm(user, message: str) -> None:
+    try:
+        await user.send(message)
+    except Exception as exc:  # noqa: BLE001
+        log.error("DM to %s failed: %s", user, exc)
+
+
+async def send_daily_dm(bot) -> None:
+    for uid in get_dm_users():
+        user = await bot.fetch_user(uid)
+        await send_dm(user, "Good morning! Your events for today are ready.")
+
+
+async def check_upcoming_events(bot) -> None:
+    now = datetime.utcnow()
+    target = now + timedelta(minutes=10)
+    events: Collection = get_collection("calendar_events")
+
+    for event in events.find(
+        {"start": {"$gte": now, "$lt": target}, "dm_warning_sent": {"$ne": True}}
+    ):
+        user_id = int(event.get("user_id", 0))
+        if not user_id:
+            continue
+        user = await bot.fetch_user(user_id)
+        await send_dm(user, f"\u23f0 Your event starts in 10 minutes: {event['title']}")
+        events.update_one({"_id": event["_id"]}, {"$set": {"dm_warning_sent": True}})
+
+
+def schedule_dm_tasks(bot) -> None:
+    scheduler.add_job(send_daily_dm, "cron", hour=6, minute=0, args=[bot])
+    scheduler.add_job(check_upcoming_events, "interval", minutes=1, args=[bot])
+    scheduler.start()

--- a/tests/test_dm_scheduler.py
+++ b/tests/test_dm_scheduler.py
@@ -1,0 +1,82 @@
+import types
+from datetime import datetime, timedelta
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_send_daily_dm(monkeypatch):
+    from bot import dm_scheduler as mod
+
+    called = {}
+    monkeypatch.setattr(mod, "get_dm_users", lambda: [1])
+
+    async def fake_send(user, msg):
+        called[user] = msg
+
+    monkeypatch.setattr(mod, "send_dm", fake_send)
+
+    async def fetch_user(uid):
+        return uid
+
+    fake_bot = types.SimpleNamespace(fetch_user=fetch_user)
+
+    await mod.send_daily_dm(fake_bot)
+
+    assert called.get(1) == "Good morning! Your events for today are ready."
+
+
+@pytest.mark.asyncio
+async def test_check_upcoming_events(monkeypatch):
+    from bot import dm_scheduler as mod
+
+    now = datetime.utcnow()
+    events = [{"_id": 1, "start": now + timedelta(minutes=5), "user_id": 1, "title": "Ping"}]
+
+    class FakeCollection:
+        def find(self, query):
+            return events
+
+        def update_one(self, q, u):
+            events[0]["dm_warning_sent"] = True
+
+    monkeypatch.setattr(mod, "get_collection", lambda name: FakeCollection())
+    sent = {}
+
+    async def fake_send_dm(user, text):
+        sent[user] = text
+
+    monkeypatch.setattr(mod, "send_dm", fake_send_dm)
+
+    async def fetch_user(uid):
+        return uid
+
+    fake_bot = types.SimpleNamespace(fetch_user=fetch_user)
+
+    await mod.check_upcoming_events(fake_bot)
+
+    assert sent.get(1)
+    assert events[0]["dm_warning_sent"]
+
+
+def test_schedule_dm_tasks(monkeypatch):
+    from bot import dm_scheduler as mod
+
+    jobs = []
+
+    class FakeScheduler:
+        running = False
+
+        def add_job(self, func, trigger, **kw):
+            jobs.append((func, trigger))
+
+        def start(self):
+            self.running = True
+
+    fake = FakeScheduler()
+    monkeypatch.setattr(mod, "scheduler", fake)
+
+    mod.schedule_dm_tasks("bot")
+
+    assert fake.running
+    assert len(jobs) == 2


### PR DESCRIPTION
## Summary
- create `dm_scheduler` module with daily and pre-event DM logic
- launch scheduler once the bot is ready
- test scheduling and DM helper functions

## Testing
- `black --check .`
- `flake8`
- `pytest tests/test_dm_scheduler.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6864f3694ecc8324bd50ca0ff62aedef