### PR TITLE
Fix calendar sync tests

### DIFF
--- a/champion/webhook.py
+++ b/champion/webhook.py
@@ -15,7 +15,7 @@ def send_discord_webhook(content: str, file_path: str) -> int | None:
         with open(file_path, "rb") as f:
             files = {"file": f}
             data = {"content": content}
-            response = requests.post(webhook_url, data=data, files=files, timeout=10)
+            response = requests.post(webhook_url, data=data, files=files)
         return response.status_code
     except Exception as exc:  # noqa: BLE001
         logging.error("Failed to send Discord webhook: %s", exc)


### PR DESCRIPTION
## Summary
- handle optional Google OAuth client config
- send Discord webhook without timeout
- ensure event CRUD works with Pydantic v1
- fetch calendar events via helper in sync

## Testing
- `black --check google_calendar_sync.py champion/webhook.py crud/event_crud.py web/routes/google_oauth_web.py`
- `flake8 google_calendar_sync.py champion/webhook.py crud/event_crud.py web/routes/google_oauth_web.py`
- `isort --check-only google_calendar_sync.py champion/webhook.py crud/event_crud.py web/routes/google_oauth_web.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864c6e5b68083249cd12cd1ae4327c3