### PR TITLE
Add AI intro DM and improved reminder scheduling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,7 @@ DISCORD_REDIRECT_URI=http://localhost:8080/oauth/discord/callback
 R3_ROLE_IDS=                            # Comma-separated list
 R4_ROLE_IDS=
 ADMIN_ROLE_IDS=
+ENABLE_CHANNEL_REMINDERS=false
 
 # Google Calendar
 GOOGLE_CALENDAR_ID=                    # Calendar ID (optional)

--- a/bot/bot_main.py
+++ b/bot/bot_main.py
@@ -11,8 +11,8 @@ import aiohttp
 
 from config import Config
 
+from .dm_scheduler import schedule_dm_tasks, scheduler
 from .translator import MyTranslator
-from .dm_scheduler import scheduler, schedule_dm_tasks
 
 # 🧠 Umschalten zwischen echtem Bot & Stub-Modus (z. B. für Web-Dashboard)
 USE_DISCORD_BOT = os.getenv("ENABLE_DISCORD_BOT", "false").lower() == "true"
@@ -78,6 +78,7 @@ async def load_extensions(bot_instance: commands.Bot):
         "bot.cogs.newsletter",
         "bot.cogs.reminders",
         "bot.cogs.reminder_cog",
+        "bot.cogs.intro_cog",
         "bot.cogs.reaction_signup",
         "bot.cogs.calendar_cog",
         # "bot.cogs.reminder_sender_cog",  # falls später aktiv

--- a/bot/cogs/intro_cog.py
+++ b/bot/cogs/intro_cog.py
@@ -1,0 +1,74 @@
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from bot.dm_scheduler import get_dm_users
+from mongo_service import get_collection
+
+log = logging.getLogger(__name__)
+
+INTRO_JSON = Path("AI_Intro-Image.json")
+INTRO_IMAGE = Path("static/img/SORRY.png")
+
+
+class IntroCog(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.bot.loop.create_task(self._maybe_send_intro())
+
+    @staticmethod
+    def _load_embed() -> discord.Embed | None:
+        if not INTRO_JSON.is_file():
+            log.warning("intro json missing")
+            return None
+        try:
+            data = json.loads(INTRO_JSON.read_text())
+            embed_data = data.get("embeds", [{}])[0]
+            return discord.Embed.from_dict(embed_data)
+        except Exception as exc:  # noqa: BLE001
+            log.error("failed to load intro json: %s", exc)
+            return None
+
+    async def _send_intro(self) -> None:
+        embed = self._load_embed()
+        if not embed or not INTRO_IMAGE.is_file():
+            return
+        file_path = INTRO_IMAGE
+        for uid in get_dm_users():
+            try:
+                user = await self.bot.fetch_user(uid)
+                await user.send(embed=embed, file=discord.File(file_path))
+            except Exception as exc:  # noqa: BLE001
+                log.error("intro DM to %s failed: %s", uid, exc)
+
+    async def _maybe_send_intro(self) -> None:
+        await self.bot.wait_until_ready()
+        flags = get_collection("flags")
+        if flags.find_one({"_id": "ai_intro_sent", "value": True}):
+            return
+        await self._send_intro()
+        flags.update_one(
+            {"_id": "ai_intro_sent"},
+            {"$set": {"value": True, "sent_at": datetime.utcnow()}},
+            upsert=True,
+        )
+
+    @app_commands.command(name="ai_sorry", description="Send intro message again")
+    async def ai_sorry(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True)
+        await self._send_intro()
+        get_collection("flags").update_one(
+            {"_id": "ai_intro_sent"},
+            {"$set": {"value": True, "sent_at": datetime.utcnow()}},
+            upsert=True,
+        )
+        await interaction.followup.send("Intro message sent", ephemeral=True)
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(IntroCog(bot))

--- a/bot/cogs/reminders.py
+++ b/bot/cogs/reminders.py
@@ -12,6 +12,7 @@ from config import Config, is_production
 from fur_lang.i18n import t
 
 log = logging.getLogger(__name__)
+ENABLE_CHANNEL_REMINDERS = os.getenv("ENABLE_CHANNEL_REMINDERS", "false").lower() == "true"
 
 
 class Reminders(commands.Cog):
@@ -37,6 +38,8 @@ class Reminders(commands.Cog):
     @tasks.loop(minutes=60)
     async def reminder_loop(self):
         """Sendet jede Stunde eine Erinnerungsnachricht an den Reminder-Channel."""
+        if not ENABLE_CHANNEL_REMINDERS:
+            return
         if not is_production():
             log.info("DM skipped in dev mode")
             return

--- a/bot/dm_scheduler.py
+++ b/bot/dm_scheduler.py
@@ -27,9 +27,14 @@ async def send_dm(user, message: str) -> None:
 
 
 async def send_daily_dm(bot) -> None:
+    today = datetime.utcnow().date().isoformat()
+    flags = get_collection("flags")
+    if flags.find_one({"_id": "daily_dm", "date": today}):
+        return
     for uid in get_dm_users():
         user = await bot.fetch_user(uid)
         await send_dm(user, "Good morning! Your events for today are ready.")
+    flags.update_one({"_id": "daily_dm"}, {"$set": {"date": today}}, upsert=True)
 
 
 async def check_upcoming_events(bot) -> None:

--- a/tests/test_dm_scheduler.py
+++ b/tests/test_dm_scheduler.py
@@ -16,6 +16,23 @@ async def test_send_daily_dm(monkeypatch):
 
     monkeypatch.setattr(mod, "send_dm", fake_send)
 
+    class FakeFlags:
+        def __init__(self) -> None:
+            self.updated = False
+
+        def find_one(self, q):
+            return None
+
+        def update_one(self, q, u, upsert=False):
+            self.updated = True
+
+    flags = FakeFlags()
+
+    def fake_get_collection(name):
+        return flags if name == "flags" else None
+
+    monkeypatch.setattr(mod, "get_collection", fake_get_collection)
+
     async def fetch_user(uid):
         return uid
 
@@ -24,6 +41,7 @@ async def test_send_daily_dm(monkeypatch):
     await mod.send_daily_dm(fake_bot)
 
     assert called.get(1) == "Good morning! Your events for today are ready."
+    assert flags.updated
 
 
 @pytest.mark.asyncio

--- a/tests/test_hourly_reminder.py
+++ b/tests/test_hourly_reminder.py
@@ -39,6 +39,7 @@ async def test_sends_if_open_tasks(monkeypatch):
     bot = types.SimpleNamespace(wait_until_ready=ready, get_channel=lambda cid: channel)
 
     monkeypatch.setattr(rem_mod.tasks.Loop, "start", lambda self, *a, **k: None)
+    monkeypatch.setenv("ENABLE_CHANNEL_REMINDERS", "true")
     monkeypatch.setattr(rem_mod, "t", fake_t)
     monkeypatch.setattr(rem_mod, "get_collection", lambda name: DummyCollection(count=1))
     now = datetime.utcnow()
@@ -60,6 +61,7 @@ async def test_no_send_if_recent(monkeypatch):
     bot = types.SimpleNamespace(wait_until_ready=ready, get_channel=lambda cid: channel)
 
     monkeypatch.setattr(rem_mod.tasks.Loop, "start", lambda self, *a, **k: None)
+    monkeypatch.setenv("ENABLE_CHANNEL_REMINDERS", "true")
     monkeypatch.setattr(rem_mod, "t", fake_t)
     monkeypatch.setattr(rem_mod, "get_collection", lambda name: DummyCollection(count=1))
     now = datetime.utcnow()

--- a/tests/test_intro_cog.py
+++ b/tests/test_intro_cog.py
@@ -1,0 +1,52 @@
+import asyncio
+import json
+import types
+from pathlib import Path
+
+import pytest
+
+from bot.cogs import intro_cog as mod
+
+
+class FakeUser:
+    def __init__(self):
+        self.sent = False
+
+    async def send(self, *, embed=None, file=None):
+        self.sent = True
+
+
+@pytest.mark.asyncio
+async def test_maybe_send_intro(monkeypatch, tmp_path):
+    intro_json = tmp_path / "intro.json"
+    intro_json.write_text(json.dumps({"embeds": [{"title": "T"}]}))
+    intro_img = tmp_path / "img.png"
+    intro_img.write_text("img")
+    monkeypatch.setattr(mod, "INTRO_JSON", intro_json)
+    monkeypatch.setattr(mod, "INTRO_IMAGE", intro_img)
+
+    flags = {}
+
+    class FakeCollection:
+        def find_one(self, q):
+            return flags.get("flag")
+
+        def update_one(self, q, u, upsert=False):
+            flags["flag"] = u["$set"]
+
+    monkeypatch.setattr(mod, "get_collection", lambda name: FakeCollection())
+    monkeypatch.setattr(mod, "get_dm_users", lambda: [1])
+
+    user = FakeUser()
+    fake_bot = types.SimpleNamespace(
+        fetch_user=lambda uid: user,
+        wait_until_ready=lambda: None,
+        loop=asyncio.get_event_loop(),
+    )
+
+    cog = mod.IntroCog.__new__(mod.IntroCog)
+    cog.bot = fake_bot
+    await mod.IntroCog._maybe_send_intro(cog)
+
+    assert user.sent
+    assert flags["flag"]["value"] is True


### PR DESCRIPTION
## Summary
- introduce `IntroCog` to send `AI_Intro-Image.json` once and via `/ai_sorry`
- persist daily DM flag in scheduler
- disable reminder channel postings by default
- document new environment variable
- adjust tests for scheduler and reminders

## Testing
- `black --check .`
- `isort . --check --diff`
- `flake8`
- `pytest -q` *(fails: missing environment deps)*

------
https://chatgpt.com/codex/tasks/task_e_686538753b0c83248fe4f9e7f89d57c5