### PR TITLE
Sort imports in google oauth test

### DIFF
--- a/tests/test_google_oauth_web.py
+++ b/tests/test_google_oauth_web.py
@@ -1,5 +1,6 @@
 import json
 import logging
+
 from flask import Flask
 
 from web.routes import google_oauth_web as mod


### PR DESCRIPTION
## Summary
- reorder imports in `tests/test_google_oauth_web.py` using isort

## Testing
- `isort --check tests/test_google_oauth_web.py`
- `black --check .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686608eb203083249f094d56bd1a2c4e