### PR TITLE
Improve credential logging

### DIFF
--- a/services/calendar_service.py
+++ b/services/calendar_service.py
@@ -49,6 +49,7 @@ class CalendarService:
     ) -> None:
         self.calendar_id = calendar_id or Config.GOOGLE_CALENDAR_ID
         self.service: Any | None = None
+        self.warned_missing_creds = False
         uri = mongo_uri or Config.MONGODB_URI or "mongodb://localhost:27017/furdb"
         if events_collection and tokens_collection:
             self.client = None
@@ -72,9 +73,12 @@ class CalendarService:
             return
         creds = load_credentials()
         if not creds:
-            log.warning("Google credentials missing – cannot sync")
+            if not self.warned_missing_creds:
+                log.warning("Google credentials missing – cannot sync")
+                self.warned_missing_creds = True
             self.service = None
             return
+        self.warned_missing_creds = False
         self.service = build(
             "calendar",
             "v3",

--- a/tests/test_google_sync.py
+++ b/tests/test_google_sync.py
@@ -1,5 +1,6 @@
 from datetime import timezone
 
+import logging
 import google_calendar_sync as mod
 
 
@@ -59,3 +60,16 @@ def test_all_day_event(monkeypatch):
     doc = dummy.docs["g2"]
     assert doc["event_time"].hour == 0
     assert doc["event_time"].tzinfo == timezone.utc
+
+
+def test_load_credentials_warns_once(monkeypatch, tmp_path, caplog):
+    missing = tmp_path / "token.json"
+    monkeypatch.setattr(mod, "TOKEN_PATH", missing, raising=False)
+    mod._warned_once = False
+    with caplog.at_level(logging.WARNING):
+        assert mod.load_credentials() is None
+    assert "No Google credentials found" in caplog.text
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        assert mod.load_credentials() is None
+    assert caplog.text == ""


### PR DESCRIPTION
## Summary
- avoid repeated warnings in `load_credentials` when credentials are missing
- keep CalendarService from spamming logs if credentials are absent
- add regression test for once-only credential warning

## Testing
- `black --check .`
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_687154a2ee188324b14501d1f9b57fd0