### PR TITLE
Add Bank War Recap Page

### DIFF
--- a/blueprints/public.py
+++ b/blueprints/public.py
@@ -235,6 +235,12 @@ def leaderboard():
     return render_template("public/public_leaderboard.html", leaderboard=leaderboard_list)
 
 
+@public.route("/bank-war-top5")
+def bank_war_top5():
+    """Display BANK WAR recap and top 5 players."""
+    return render_template("public/bank_war_top5.html")
+
+
 @public.route("/dashboard")
 def dashboard():
     return render_template("public/dashboard.html")

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -126,6 +126,7 @@
     <a href="{{ url_for('public.events') }}">📅 {{ t("Events") }}</a>
     <a href="{{ url_for('public.leaderboard') }}">🏆 {{ t("Leaderboard") }}</a>
     <a href="{{ url_for('public.hall_of_fame') }}">👑 {{ t("Hall of Fame") }}</a>
+    <a href="{{ url_for('public.bank_war_top5') }}">💥 BANK WAR Top 5</a>
     <a href="{{ url_for('public.lore') }}">📖 {{ t("Lore") }}</a>
     {% if role in ['R4', 'ADMIN'] %}
     <a href="{{ url_for('admin.upload') }}">⏫ {{ t("Uploads") }}</a>

--- a/templates/public/bank_war_top5.html
+++ b/templates/public/bank_war_top5.html
@@ -1,0 +1,111 @@
+{% extends "layout.html" %}
+{% set bg_image = resolve_background_template() %}
+
+{% block title %}BANK WAR – TOP 5{% endblock %}
+
+{% block content %}
+<style>
+  body {
+    font-family: "Segoe UI", sans-serif;
+    background-color: #f9f9f9;
+    color: #222;
+    padding: 20px;
+    line-height: 1.6;
+    max-width: 900px;
+    margin: auto;
+  }
+  h1, h2 {
+    text-align: center;
+    color: #333;
+  }
+  .section {
+    margin-top: 30px;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 10px;
+    background: white;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+  }
+  th, td {
+    border: 1px solid #ddd;
+    padding: 12px;
+    text-align: center;
+  }
+  th {
+    background-color: #333;
+    color: white;
+  }
+  tr:nth-child(even) {
+    background-color: #f4f4f4;
+  }
+  .footer {
+    margin-top: 40px;
+    font-size: 1.1em;
+    text-align: center;
+    font-style: italic;
+  }
+</style>
+
+<h1>📣 BANK WAR – TOP 5 & THANK YOU TO THE LEGENDS</h1>
+<p style="text-align:center"><em>Part 2/2 – Recap & Recognition</em></p>
+<p style="text-align:center; font-weight: bold;">Event: 07.07.2025 – 09.07.2025</p>
+
+<div class="section">
+  <p>
+    Even with all the chaos – <strong>you showed up.</strong> Strong. Committed. For the server. For each other.<br>
+    <strong>Thank you – from the heart. 🫶</strong>
+  </p>
+</div>
+
+<div class="section">
+  <h2>🥳 Top 5 Jubilation – Stamina Used</h2>
+  <p>🔥 <strong>Total: 82,900 stamina</strong> from the Top 5 alone!</p>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Rank</th>
+        <th>Name</th>
+        <th>Jubilation</th>
+        <th>Stamina</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr><td>🥇</td><td>BoZKuRT42</td><td>188</td><td>18,800</td></tr>
+      <tr><td>🥈</td><td>Unknown</td><td>177</td><td>17,700</td></tr>
+      <tr><td>🥉</td><td>Burak</td><td>171</td><td>17,100</td></tr>
+      <tr><td>4️⃣</td><td>BarjonoLuwing</td><td>147</td><td>14,700</td></tr>
+      <tr><td>5️⃣</td><td>Greek</td><td>146</td><td>14,600</td></tr>
+    </tbody>
+  </table>
+</div>
+
+<div class="section">
+  <h2>🏆 Top 5 Weekly Score – Total Points</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Rank</th>
+        <th>Name</th>
+        <th>Points</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr><td>🥇</td><td>SEE u RABBIT</td><td>36,328,158</td></tr>
+      <tr><td>🥈</td><td>Rexslayer</td><td>19,453,941</td></tr>
+      <tr><td>🥉</td><td>NovusSkye</td><td>17,171,885</td></tr>
+      <tr><td>4️⃣</td><td>Wally</td><td>17,130,856</td></tr>
+      <tr><td>5️⃣</td><td>Greek</td><td>13,662,421</td></tr>
+    </tbody>
+  </table>
+</div>
+
+<div class="footer">
+  Whether you made 1 point or 30 million –<br>
+  <strong>YOU are part of this family. Every effort matters. Every step in unity counts.</strong><br><br>
+  🛡️ If you're looking for a home – FUR is here. United, loyal, strong.<br>
+  <strong>There’s always a place for you among us. 🐾</strong>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `bank_war_top5.html` template
- link new page in layout navigation
- expose `/bank-war-top5` route for the public blueprint

## Testing
- `black --check .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68715c0c2a6c8324b33bf4ae219c23c9