### PR TITLE
Fix google_oauth_setup indentation and add tests

### DIFF
--- a/google_oauth_setup.py
+++ b/google_oauth_setup.py
@@ -32,9 +32,10 @@ def main() -> None:
             creds = flow.run_local_server(port=0)
         token_path.parent.mkdir(parents=True, exist_ok=True)
         import json
-with open(token_path, 'w', encoding='utf-8') as f:
-    json.dump(json.loads(creds.to_json()), f, ensure_ascii=False, indent=4)
-    logger.info("Token saved to %s", token_path)
+
+        with open(token_path, "w", encoding="utf-8") as f:
+            json.dump(json.loads(creds.to_json()), f, ensure_ascii=False, indent=4)
+        logger.info("Token saved to %s", token_path)
 
 
 if __name__ == "__main__":

--- a/tests/test_google_oauth_setup.py
+++ b/tests/test_google_oauth_setup.py
@@ -1,0 +1,28 @@
+import json
+
+import google_oauth_setup as mod
+
+
+def test_main_writes_token_file(tmp_path, monkeypatch):
+    token_path = tmp_path / "token.json"
+    cfg = tmp_path / "client.json"
+    cfg.write_text("{}")
+    monkeypatch.setenv("GOOGLE_CREDENTIALS_FILE", str(token_path))
+    monkeypatch.setenv("GOOGLE_CLIENT_CONFIG", str(cfg))
+
+    class FakeCred:
+        def to_json(self):
+            return json.dumps({"ok": True})
+
+    class FakeFlow:
+        def run_local_server(self, port=0):  # noqa: D401
+            return FakeCred()
+
+    monkeypatch.setattr(
+        mod,
+        "InstalledAppFlow",
+        type("F", (), {"from_client_secrets_file": lambda *a, **k: FakeFlow()}),
+    )
+
+    mod.main()
+    assert json.loads(token_path.read_text()) == {"ok": True}


### PR DESCRIPTION
## Summary
- indent token writing logic inside `google_oauth_setup.main`
- ensure no side effects at import
- add unit test verifying token file creation

## Testing
- `flake8 | head -n 20`
- `black --check . | head -n 20`
- `pytest tests/test_google_oauth_setup.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687431e53ab48324aaa389290d94e129