### PR TITLE
Sanitize OAuth client files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,8 +38,8 @@ GOOGLE_SYNC_INTERVAL_MINUTES=2         # Sync interval
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 GOOGLE_REDIRECT_URI=http://localhost:8080/oauth/google/callback
-GOOGLE_CLIENT_CONFIG=credentials/client_secret.json  # Path to OAuth client config
-GOOGLE_CREDENTIALS_FILE=/data/google_token.json       # Token storage path
+GOOGLE_CLIENT_CONFIG=client_secret.json              # Path to OAuth client config
+GOOGLE_CREDENTIALS_FILE=credentials/oauth_client.json # Token storage path
 GOOGLE_CALENDAR_SCOPES=https://www.googleapis.com/auth/calendar.readonly
 
 # Poster and web

--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,8 @@ instance/
 .coverage
 
 # Google OAuth credentials
-credentials/client_secret.json
+client_secret.json
+credentials/oauth_client.json
 token/
 
 # Node / Frontend (falls vorhanden)

--- a/client_secret.json
+++ b/client_secret.json
@@ -1,16 +1,13 @@
 {
   "web": {
-    "client_id": "490265976573-3l3q19eoeeikaojdnfnv4mr5rt87e5vq.apps.googleusercontent.com",
-    "project_id": "fur-sync",
+    "client_id": "your-client-id.apps.googleusercontent.com",
+    "project_id": "example-project",
     "auth_uri": "https://accounts.google.com/o/oauth2/auth",
     "token_uri": "https://oauth2.googleapis.com/token",
     "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-    "client_secret": "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",
+    "client_secret": "your-client-secret",
     "redirect_uris": [
-      "https://fur-martix.up.railway.app/oauth2callback",
-      "http://localhost:8080/",
-      "http://127.0.0.1:8080/",
-      "https://c70e1091-babc-4f59-aa9c-b5e95d7f254e-00-n83os30wj6el.picard.replit.dev:8080/oauth2callback"
+      "http://localhost:8080/oauth2callback"
     ]
   }
 }

--- a/credentials/oauth_client.json
+++ b/credentials/oauth_client.json
@@ -1,16 +1,13 @@
 {
   "web": {
-    "client_id": "490265976573-3l3q19eoeeikaojdnfnv4mr5rt87e5vq.apps.googleusercontent.com",
-    "project_id": "fur-sync",
+    "client_id": "your-client-id.apps.googleusercontent.com",
+    "project_id": "example-project",
     "auth_uri": "https://accounts.google.com/o/oauth2/auth",
     "token_uri": "https://oauth2.googleapis.com/token",
     "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-    "client_secret": "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",
+    "client_secret": "your-client-secret",
     "redirect_uris": [
-      "https://fur-martix.up.railway.app/oauth2callback",
-      "http://localhost:8080/",
-      "http://127.0.0.1:8080/",
-      "https://c70e1091-babc-4f59-aa9c-b5e95d7f254e-00-n83os30wj6el.picard.replit.dev:8080/oauth2callback"
+      "http://localhost:8080/oauth2callback"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- add example OAuth client JSON files
- ignore OAuth client credentials in git
- document OAuth paths in `.env.example`

## Testing
- `black --check .` *(fails: Cannot parse intro_cog.py)*
- `flake8`
- `pytest -q` *(fails: IndentationError in intro_cog.py)*

------
https://chatgpt.com/codex/tasks/task_e_6874355970e8832483de618f59b887e2