### PR TITLE
Validate OAuth token JSON before use

### DIFF
--- a/tests/test_google_sync.py
+++ b/tests/test_google_sync.py
@@ -73,3 +73,13 @@ def test_load_credentials_warns_once(monkeypatch, tmp_path, caplog):
     with caplog.at_level(logging.WARNING):
         assert mod.load_credentials() is None
     assert caplog.text == ""
+
+
+def test_load_credentials_client_config(monkeypatch, tmp_path, caplog):
+    path = tmp_path / "client.json"
+    path.write_text("{""installed"": {""client_id"": ""id"", ""client_secret"": ""sec""}}")
+    monkeypatch.setattr(mod, "TOKEN_PATH", path, raising=False)
+    mod._warned_once = False
+    with caplog.at_level(logging.WARNING):
+        assert mod.load_credentials() is None
+    assert "client config" in caplog.text


### PR DESCRIPTION
## Summary
- verify stored Google credentials contain `client_id`, `client_secret`, and `refresh_token`
- warn if the credentials file looks like a client config
- test loading credentials when a client config is provided

## Testing
- `black --check .` *(fails: cannot parse intro_cog.py)*
- `flake8` *(fails: indentation error in intro_cog.py)*
- `pytest -q` *(fails: IndentationError in intro_cog.py)*

------
https://chatgpt.com/codex/tasks/task_e_687437458110832485727add5a1624f3