### PR TITLE
Fix scheduler sync loop

### DIFF
--- a/agents/scheduler_agent.py
+++ b/agents/scheduler_agent.py
@@ -9,11 +9,9 @@ from datetime import datetime
 import schedule
 
 from champion.autopilot import run_champion_autopilot
-from config import Config
-from google_calendar_sync import sync_to_mongodb
 from mongo_service import get_collection
 from utils import champion_data
-from utils.google_sync_task import _get_app, start_google_sync
+from utils.google_sync_task import start_google_sync
 
 
 class SchedulerAgent:
@@ -70,18 +68,3 @@ class SchedulerAgent:
             "\U0001f4c5 Google Calendar sync every %s minutes scheduled via loop",
             interval_minutes,
         )
-
-        interval = interval_minutes or Config.GOOGLE_SYNC_INTERVAL_MINUTES
-        if hasattr(schedule, "every"):
-
-            def _job_wrapper():
-                app = _get_app()
-                with app.app_context():
-                    sync_to_mongodb()
-
-            job = schedule.every(interval).minutes.do(_job_wrapper)
-            self.jobs.append(job)
-            logging.info(
-                "\U0001f4c5 Google Calendar sync every %s minutes scheduled",
-                interval,
-            )

--- a/bot/cogs/intro_cog.py
+++ b/bot/cogs/intro_cog.py
@@ -21,7 +21,8 @@ class IntroCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         asyncio.create_task(self._maybe_send_intro())
-        async def _hook(self):
+
+    async def _hook(self) -> None:
         await self.bot.wait_until_ready()
         await self._maybe_send_intro()
 

--- a/tests/test_google_sync.py
+++ b/tests/test_google_sync.py
@@ -77,7 +77,7 @@ def test_load_credentials_warns_once(monkeypatch, tmp_path, caplog):
 
 def test_load_credentials_client_config(monkeypatch, tmp_path, caplog):
     path = tmp_path / "client.json"
-    path.write_text("{""installed"": {""client_id"": ""id"", ""client_secret"": ""sec""}}")
+    path.write_text('{"installed": {"client_id": "id", "client_secret": "sec"}}')
     monkeypatch.setattr(mod, "TOKEN_PATH", path, raising=False)
     mod._warned_once = False
     with caplog.at_level(logging.WARNING):


### PR DESCRIPTION
## Summary
- fix IntroCog _hook indentation
- clean up google sync scheduling to avoid duplicate jobs
- adjust tests for simplified scheduling
- ensure JSON config test uses valid JSON

## Testing
- `black --check .` *(fails: 4 files would be reformatted)*
- `flake8` *(fails: 12 warnings/errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68743ce590688324a2a51341629d1802