### PR TITLE
Add LangChain MongoDB service

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
   "Flask-SocketIO>=5.3",
   "python-dotenv>=1.0.1",
   "Markdown>=3.0",
+  "langchain>=0.3.0",
+  "langchain-mongodb>=0.6.2",
   "google-api-python-client>=2.125.0"
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,8 @@ python-telegram-bot==22.1
 # 📦 Utilities
 requests==2.32.3
 openai>=1.14
+langchain>=0.3.0
+langchain-mongodb>=0.6.2
 python-dotenv==1.1.0
 python-dateutil
 pytz

--- a/services/langchain_service.py
+++ b/services/langchain_service.py
@@ -1,0 +1,36 @@
+import os
+from langchain.embeddings.base import Embeddings
+from langchain_mongodb import MongoDBAtlasVectorSearch, MongoDBChatMessageHistory
+
+from config import Config
+
+
+class LangchainService:
+    """Helper for LangChain integrations using MongoDB."""
+
+    def __init__(self, mongo_uri: str | None = None, db_name: str | None = None) -> None:
+        self.mongo_uri = mongo_uri or Config.MONGODB_URI or "mongodb://localhost:27017/furdb"
+        self.db_name = db_name or os.getenv("MONGO_DB", "furdb")
+
+    def get_history(self, session_id: str) -> MongoDBChatMessageHistory:
+        """Return a chat history object for the session."""
+        return MongoDBChatMessageHistory(
+            connection_string=self.mongo_uri,
+            session_id=session_id,
+            database_name=self.db_name,
+            collection_name="chat_history",
+        )
+
+    def get_vector_store(
+        self, embedding: Embeddings, namespace: str = "embeddings"
+    ) -> MongoDBAtlasVectorSearch:
+        """Return a vector store backed by MongoDB Atlas Vector Search."""
+        ns = f"{self.db_name}.{namespace}"
+        return MongoDBAtlasVectorSearch.from_connection_string(
+            self.mongo_uri,
+            ns,
+            embedding,
+        )
+
+
+__all__ = ["LangchainService"]

--- a/tests/test_langchain_service.py
+++ b/tests/test_langchain_service.py
@@ -1,0 +1,66 @@
+import types
+
+import pytest
+
+import services.langchain_service as mod
+
+
+class DummyEmbeddings:
+    def embed_documents(self, texts):
+        return [[0.0] * 3 for _ in texts]
+
+    def embed_query(self, text):
+        return [0.0] * 3
+
+
+def test_get_history(monkeypatch):
+    captured = {}
+
+    class FakeHistory:
+        pass
+
+    def fake_init(connection_string, session_id, database_name, collection_name):
+        captured.update(
+            {
+                "uri": connection_string,
+                "session_id": session_id,
+                "db": database_name,
+                "collection": collection_name,
+            }
+        )
+        return FakeHistory()
+
+    monkeypatch.setattr(mod, "MongoDBChatMessageHistory", fake_init)
+
+    svc = mod.LangchainService(mongo_uri="uri", db_name="db")
+    history = svc.get_history("sess")
+    assert isinstance(history, FakeHistory)
+    assert captured == {
+        "uri": "uri",
+        "session_id": "sess",
+        "db": "db",
+        "collection": "chat_history",
+    }
+
+
+def test_get_vector_store(monkeypatch):
+    captured = {}
+
+    class FakeStore:
+        pass
+
+    def fake_from_connection_string(uri, namespace, embedding):
+        captured.update({"uri": uri, "ns": namespace, "embed": embedding})
+        return FakeStore()
+
+    monkeypatch.setattr(
+        mod.MongoDBAtlasVectorSearch, "from_connection_string", fake_from_connection_string
+    )
+
+    emb = DummyEmbeddings()
+    svc = mod.LangchainService(mongo_uri="uri", db_name="db")
+    store = svc.get_vector_store(emb, namespace="ns")
+    assert isinstance(store, FakeStore)
+    assert captured["uri"] == "uri"
+    assert captured["ns"] == "db.ns"
+    assert captured["embed"] is emb


### PR DESCRIPTION
## Summary
- add langchain and langchain-mongodb deps
- implement `LangchainService` for chat history and vector store
- test service with dummy embeddings

## Testing
- `pytest -q tests/test_langchain_service.py`
- `black --check .` *(fails: would reformat some files)*
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_6877d4825ab08324a8c92d0dd5a9184e