### PR TITLE
Add Prometheus monitoring

### DIFF
--- a/blueprints/__init__.py
+++ b/blueprints/__init__.py
@@ -4,8 +4,9 @@ from .admin import admin
 from .api_events import api_events
 from .api_users import api_users
 from .public import public
+from .monitoring import monitoring
 
-__all__ = ["admin", "api_events", "api_users", "public"]
+__all__ = ["admin", "api_events", "api_users", "public", "monitoring"]
 
 # ... weitere Blueprints, z. B.:
 # from .leaderboard import leaderboard

--- a/blueprints/monitoring.py
+++ b/blueprints/monitoring.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from flask import Blueprint, Response
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
+
+monitoring = Blueprint("monitoring", __name__)
+
+# Metrics
+GPT_RESPONSE_TIME = Histogram("gpt_response_seconds", "Time spent waiting for GPT responses")
+GPT_ERROR_COUNT = Counter("gpt_errors_total", "Number of GPT errors")
+
+
+@monitoring.route("/metrics")
+def metrics() -> Response:
+    """Expose Prometheus metrics."""
+    return Response(generate_latest(), mimetype=CONTENT_TYPE_LATEST)

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,32 @@
+# Monitoring with Prometheus and Grafana
+
+This project exposes application metrics compatible with Prometheus. The metrics endpoint is available at `/metrics` and can be scraped by a Prometheus server.
+
+```txt
+GET /metrics
+```
+
+## Grafana Dashboard
+
+You can visualize the metrics using Grafana. Below is a minimal dashboard JSON that displays GPT response times and error rates.
+
+```json
+{
+  "dashboard": {
+    "panels": [
+      {
+        "type": "graph",
+        "title": "GPT Response Time",
+        "targets": [{"expr": "gpt_response_seconds"}]
+      },
+      {
+        "type": "graph",
+        "title": "GPT Errors",
+        "targets": [{"expr": "gpt_errors_total"}]
+      }
+    ]
+  }
+}
+```
+
+Import this JSON into Grafana to get started.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
   "Flask-SocketIO>=5.3",
   "python-dotenv>=1.0.1",
   "Markdown>=3.0",
+  "prometheus-client>=0.20.0",
   "langchain>=0.3.0",
   "langchain-mongodb>=0.6.2",
   "google-api-python-client>=2.125.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ motor
 flask-limiter
 Flask-SocketIO
 pydantic>=1.10.12,<2.0.0
+prometheus-client>=0.20.0
 
 # 📚 Datenbank & Planung
 SQLAlchemy==2.0.41

--- a/tests/test_monitoring_metrics.py
+++ b/tests/test_monitoring_metrics.py
@@ -1,0 +1,7 @@
+from flask.testing import FlaskClient
+
+
+def test_metrics_endpoint(client: FlaskClient):
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    assert b"gpt_response_seconds" in resp.data

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -20,6 +20,7 @@ from web.champion_routes import champion_blueprint
 from web.poster_routes import poster_blueprint
 from web.reminder_routes import reminder_blueprint
 from web.socketio_events import init_socketio
+from blueprints.monitoring import monitoring
 
 # ---------------------------------------------------------------------------
 # 🔹 Hilfsfunktion (Fallback für BG-Resolver)
@@ -145,6 +146,7 @@ def create_app() -> Flask:
         # API-Blueprints
         app.register_blueprint(api_events)
         app.register_blueprint(api_users)
+        app.register_blueprint(monitoring)
 
         app.logger.info("✅ Alle Blueprints erfolgreich registriert.")
     except Exception:


### PR DESCRIPTION
## Summary
- add `monitoring` blueprint with Prometheus `/metrics`
- instrument GPT calls with latency and error counters
- document dashboard in `docs/monitoring.md`
- test that `/metrics` endpoint is available
- include prometheus-client dependency

## Testing
- `black --check agents/agent_core.py blueprints/monitoring.py blueprints/__init__.py web/__init__.py tests/test_monitoring_metrics.py`
- `flake8 agents/agent_core.py blueprints/monitoring.py blueprints/__init__.py web/__init__.py tests/test_monitoring_metrics.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6877e5a94bc48324a4d089920cd3af8e