### PR TITLE
Improve deploy workflow with Docker and docs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy:
+  lint-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -19,11 +19,42 @@ jobs:
       - run: isort . --check-only
       - run: flake8 .
       - run: pytest -v
-      - name: Trigger Railway Deploy
-        env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-          PROJECT_ID: ${{ secrets.RAILWAY_PROJECT }}
-        run: |
-          curl -X POST https://backboard.railway.app/project/${PROJECT_ID}/deploy \
-            -H "Authorization: Bearer ${RAILWAY_TOKEN}" \
-            -H "Content-Type: application/json"
+
+  build-and-deploy:
+    needs: lint-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build Docker image
+        run: docker build -t ${{ secrets.DOCKER_REGISTRY }}/${{ secrets.DOCKER_IMAGE }}:${{ github.sha }} .
+      - name: Login to registry
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login ${{ secrets.DOCKER_REGISTRY }} -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+      - name: Push image
+        run: docker push ${{ secrets.DOCKER_REGISTRY }}/${{ secrets.DOCKER_IMAGE }}:${{ github.sha }}
+      - name: Deploy to host
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_KEY }}
+          script: |
+            docker pull ${{ secrets.DOCKER_REGISTRY }}/${{ secrets.DOCKER_IMAGE }}:${{ github.sha }}
+            docker stop fur_app || true
+            docker rm fur_app || true
+            docker run -d --name fur_app -p 8000:8000 ${{ secrets.DOCKER_REGISTRY }}/${{ secrets.DOCKER_IMAGE }}:${{ github.sha }}
+
+  docs:
+    needs: lint-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: python -m pip install --upgrade pip
+      - run: pip install sphinx myst-parser
+      - run: sphinx-build -b html docs docs/_build
+      - uses: actions/upload-artifact@v3
+        with:
+          name: documentation
+          path: docs/_build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,12 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(".."))
+
+project = "FUR System"
+extensions = ["myst_parser"]
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
+html_theme = "alabaster"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,10 @@
+Welcome to FUR System's documentation!
+======================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   fine_tuning
+   i18n
+   monitoring


### PR DESCRIPTION
## Summary
- add minimal Sphinx project for docs
- extend deploy workflow to run lint/tests, build Docker image, deploy to host
- generate docs and upload as artifact

## Testing
- `black --check .` *(fails: would reformat four files)*
- `flake8 .`
- `pytest -q` *(failed to run due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687809a20668832482e483018d2cfb96