### PR TITLE
Update dependency pins

### DIFF
--- a/Fehlende_ENV_LOG.md
+++ b/Fehlende_ENV_LOG.md
@@ -68,10 +68,8 @@
 # Paketkonflikte
 
 > Detektierter Versionskonflikt:
-- pydantic<2.0.0
-- langchain>=0.3.0
+- pydantic>=2.7.4
+- langchain>=0.3.26
 - openai>=1.14
 
-## Loesungsvorschlaege:
-- Downgrade langchain auf <0.3.0 (z.B. 0.1.17)
-- Fixiere openai auf 1.14.0
+pip loest pydantic>=2.7.4 automatisch auf.

--- a/codex_fix_dependencies.py
+++ b/codex_fix_dependencies.py
@@ -9,8 +9,8 @@ LOG_PATH = Path("Fehlende_ENV_LOG.md")
 
 
 PACKAGES_TO_FIX = {
-    "langchain": "langchain==0.1.17",
-    "openai": "openai==1.14.0",
+    "langchain": "langchain>=0.3.26",
+    "openai": "openai>=1.14",
 }
 
 
@@ -37,7 +37,7 @@ def resolve_requirements() -> None:
             resolved_lines.append(raw_line)
             continue
         pkg = re.split("[<>=]", line, 1)[0].lower()
-        if pkg == "langchain" and ">=0.3.0" in line:
+        if pkg == "langchain" and ">=0.3.26" in line:
             conflict = True
         replacement = PACKAGES_TO_FIX.get(pkg)
         resolved_lines.append(replacement if replacement else raw_line)
@@ -52,10 +52,8 @@ def resolve_requirements() -> None:
         f.write("\n# Paketkonflikte\n\n")
         if conflict:
             f.write("> Detektierter Versionskonflikt:\n")
-            f.write("- pydantic<2.0.0\n- langchain>=0.3.0\n- openai>=1.14\n")
-            f.write("\n## Loesungsvorschlaege:\n")
-            f.write("- Downgrade langchain auf <0.3.0 (z.B. 0.1.17)\n")
-            f.write("- Fixiere openai auf 1.14.0\n")
+            f.write("- pydantic>=2.7.4\n- langchain>=0.3.26\n- openai>=1.14\n")
+            f.write("\npip loest pydantic>=2.7.4 automatisch auf.\n")
         else:
             f.write("Keine Konflikte erkannt.\n")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pymongo==4.3.3
 motor
 flask-limiter
 Flask-SocketIO
-pydantic>=1.10.12,<2.0.0
+# pydantic now resolved via transitive dependencies
 prometheus-client>=0.20.0
 
 # 📚 Datenbank & Planung
@@ -30,7 +30,7 @@ python-telegram-bot==22.1
 requests==2.32.3
 PyGithub>=2.3.0
 openai>=1.14
-langchain>=0.3.0
+langchain>=0.3.26
 langchain-mongodb>=0.6.2
 python-dotenv==1.1.0
 python-dateutil

--- a/requirements_resolved.txt
+++ b/requirements_resolved.txt
@@ -7,7 +7,7 @@ pymongo==4.3.3
 motor
 flask-limiter
 Flask-SocketIO
-pydantic>=1.10.12,<2.0.0
+# pydantic now resolved via transitive dependencies
 prometheus-client>=0.20.0
 
 # 📚 Datenbank & Planung
@@ -29,8 +29,8 @@ python-telegram-bot==22.1
 # 📦 Utilities
 requests==2.32.3
 PyGithub>=2.3.0
-openai==1.14.0
-langchain==0.1.17
+openai>=1.14
+langchain>=0.3.26
 langchain-mongodb>=0.6.2
 python-dotenv==1.1.0
 python-dateutil


### PR DESCRIPTION
## Summary
- unpin pydantic and set langchain>=0.3.26
- update codex_fix_dependencies to reflect new minimum versions
- remove obsolete downgrade advice in Fehlende_ENV_LOG

## Testing
- `black --check .` *(fails: 4 files would be reformatted)*
- `flake8` *(fails: various style errors)*
- `pytest -q` *(fails: missing modules like discord)*

------
https://chatgpt.com/codex/tasks/task_e_68789c4c97788324bc57f6f5d70174e1