### PR TITLE
Fix motor dependency pin

### DIFF
--- a/codex_fix_dependencies.py
+++ b/codex_fix_dependencies.py
@@ -11,6 +11,8 @@ LOG_PATH = Path("Fehlende_ENV_LOG.md")
 PACKAGES_TO_FIX = {
     "langchain": "langchain>=0.3.26",
     "openai": "openai>=1.14",
+    "motor": "motor>=3.2.0",
+    "pymongo": "pymongo==4.13.2",
 }
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@ flask==2.3.3
 Flask-Session==0.8.0
 flask-babel @ git+https://github.com/python-babel/flask-babel.git
 flask-wtf
-pymongo==4.3.3
-motor
+pymongo==4.13.2
+motor>=3.2.0
 flask-limiter
 Flask-SocketIO
 # pydantic now resolved via transitive dependencies

--- a/requirements_resolved.txt
+++ b/requirements_resolved.txt
@@ -3,8 +3,8 @@ flask==2.3.3
 Flask-Session==0.8.0
 flask-babel @ git+https://github.com/python-babel/flask-babel.git
 flask-wtf
-pymongo==4.3.3
-motor
+pymongo==4.13.2
+motor>=3.2.0
 flask-limiter
 Flask-SocketIO
 # pydantic now resolved via transitive dependencies


### PR DESCRIPTION
## Summary
- bump pymongo for motor>=3.2
- pin motor to `>=3.2.0`
- update codex_fix_dependencies accordingly

## Testing
- `pip install -r requirements.txt`
- `black --check .` *(fails: would reformat 4 files)*
- `flake8` *(fails with 14 errors)*
- `pytest` *(fails: 2 failed, 173 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68789ac9a61883248b6fb71f10cbe312