### PR TITLE
Fix intro cog async initialization

### DIFF
--- a/bot/cogs/intro_cog.py
+++ b/bot/cogs/intro_cog.py
@@ -27,7 +27,7 @@ class IntroCog(commands.Cog):
         await self._maybe_send_intro()
 
     async def cog_load(self):
-        self.bot.loop.create_task(self._hook())
+        asyncio.create_task(self._hook())
 
     @staticmethod
     def _load_embed() -> discord.Embed | None:


### PR DESCRIPTION
## Summary
- ensure IntroCog uses `asyncio.create_task` instead of removed `bot.loop`

## Testing
- `black --check .` *(fails: would reformat 4 files)*
- `flake8` *(fails: E402, F401, etc.)*
- `pytest -q` *(fails: ModuleNotFoundError: discord, google auth dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6878a9115b9883248f0b1c7e1c9b65e3