### PR TITLE
Fix collection fallback checks

### DIFF
--- a/crud/event_crud.py
+++ b/crud/event_crud.py
@@ -22,7 +22,7 @@ async def create_event(
     col=None,
 ) -> EventModel:
     """Insert a new event document."""
-    col = col or collection
+    col = col if col is not None else collection
     if hasattr(event, "model_dump"):
         data = event.model_dump(by_alias=True)
     else:  # pragma: no cover - Pydantic < 2
@@ -40,7 +40,7 @@ async def get_event_by_id(
     col=None,
 ) -> Optional[EventModel]:
     """Return a single event by ObjectId."""
-    col = col or collection
+    col = col if col is not None else collection
     if not isinstance(event_id, ObjectId):
         event_id = ObjectId(event_id)
     doc = await asyncio.to_thread(col.find_one, {"_id": event_id})
@@ -53,7 +53,7 @@ async def delete_event_by_id(
     col=None,
 ) -> int:
     """Delete an event by its ObjectId. Returns number of deleted docs."""
-    col = col or collection
+    col = col if col is not None else collection
     if not isinstance(event_id, ObjectId):
         event_id = ObjectId(event_id)
     res = await asyncio.to_thread(col.delete_one, {"_id": event_id})
@@ -66,7 +66,7 @@ async def get_events_by_guild(
     col=None,
 ) -> List[EventModel]:
     """Return all events for a Discord guild."""
-    col = col or collection
+    col = col if col is not None else collection
     docs = await asyncio.to_thread(lambda: list(col.find({"guild_id": guild_id})))
     return [EventModel(**d) for d in docs]
 
@@ -78,7 +78,7 @@ async def get_events_in_range(
     col=None,
 ) -> List[EventModel]:
     """Return events between ``start`` and ``end`` sorted by time."""
-    col = col or collection
+    col = col if col is not None else collection
     docs = await asyncio.to_thread(
         lambda: list(col.find({"event_time": {"$gte": start, "$lt": end}}).sort("event_time", 1))
     )
@@ -91,7 +91,7 @@ async def upsert_event(
     col=None,
 ) -> None:
     """Upsert an event document by ``google_id`` field."""
-    col = col or collection
+    col = col if col is not None else collection
     if asyncio.iscoroutinefunction(col.update_one):
         await col.update_one({"google_id": data["google_id"]}, {"$set": data}, upsert=True)
     else:  # pragma: no cover - sync collections


### PR DESCRIPTION
## Summary
- avoid truthy evaluation of Mongo collections in event CRUD

## Testing
- `black --check .` *(fails: would reformat other files)*
- `flake8` *(fails: various style errors)*
- `pytest -q` *(fails: missing dependencies like bleach, aiodns, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6878b2acdec88324859efd324feaca38