### PR TITLE
Fix calendar service init checks

### DIFF
--- a/services/calendar_service.py
+++ b/services/calendar_service.py
@@ -68,7 +68,7 @@ class CalendarService:
         self.service: Any | None = None
         self.warned_missing_creds = False
         uri = mongo_uri or Config.MONGODB_URI or "mongodb://localhost:27017/furdb"
-        if events_collection and tokens_collection:
+        if events_collection is not None and tokens_collection is not None:
             self.client = None
             self.events = events_collection
             self.tokens = tokens_collection


### PR DESCRIPTION
## Summary
- use explicit None checks in `CalendarService` init

## Testing
- `black --check .` *(fails: would reformat files)*
- `flake8` *(fails: E402, W292, F401, etc.)*
- `pytest -q` *(fails: multiple ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6878b7730c38832485c1089d364b4101