### PR TITLE
Update OAuth token exchange

### DIFF
--- a/tests/test_oauth_utils.py
+++ b/tests/test_oauth_utils.py
@@ -25,3 +25,27 @@ def test_generate_code_challenge_known_value():
     challenge = mod.generate_code_challenge(verifier)
     expected = "ktZu5ELbnUnx97HKaZsNZbfVaXdT1D2IdagpxxtQEI0"
     assert challenge == expected
+
+
+def test_exchange_code_for_token_payload_includes_client_secret(monkeypatch):
+    def fake_post(url, data=None, timeout=10):
+        fake_post.called_data = data
+
+        class Resp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):  # noqa: D401 - dummy
+                return {}
+
+        return Resp()
+
+    monkeypatch.setattr(mod.requests, "post", fake_post)
+    mod.exchange_code_for_token(
+        code="abc",
+        code_verifier="ver",
+        client_id="cid",
+        redirect_uri="uri",
+        client_secret="secret",
+    )
+    assert fake_post.called_data["client_secret"] == "secret"

--- a/utils/oauth_utils.py
+++ b/utils/oauth_utils.py
@@ -75,6 +75,7 @@ def exchange_code_for_token(
     code_verifier: str,
     client_id: str,
     redirect_uri: str,
+    client_secret: str,
 ) -> dict:
     """Exchange authorization ``code`` for OAuth tokens."""
     data = {
@@ -82,6 +83,7 @@ def exchange_code_for_token(
         "code": code,
         "code_verifier": code_verifier,
         "client_id": client_id,
+        "client_secret": client_secret,
         "redirect_uri": redirect_uri,
     }
     response = requests.post(_GOOGLE_TOKEN_URL, data=data, timeout=10)


### PR DESCRIPTION
## Summary
- expand OAuth POST payload to include `client_secret`
- test for outgoing payload

## Testing
- `black --check .`
- `flake8`
- `pytest -q` *(fails: ValidationError in EventModel)*

------
https://chatgpt.com/codex/tasks/task_e_687ebda1936c832493d0422b257e017a