### PR TITLE
Improve OAuth error details

### DIFF
--- a/tests/test_google_oauth_web.py
+++ b/tests/test_google_oauth_web.py
@@ -152,7 +152,9 @@ def test_oauth2callback_fetch_failure(tmp_path, monkeypatch):
     mod.state_map["good"] = 0.0
     resp = client.get("/oauth2callback?state=good")
     assert resp.status_code == 400
-    assert b"Authentication failed" in resp.data
+    assert resp.is_json
+    assert resp.json["error"].startswith("Authentication failed")
+    assert resp.json["details"] is None
 
 
 def test_oauth2callback_save_failure(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- show more detailed Google OAuth error logs
- include API response text in error JSON
- adjust OAuth web tests for JSON details

## Testing
- `black --check google_auth.py web/routes/google_oauth_web.py tests/test_google_oauth_web.py`
- `flake8 google_auth.py web/routes/google_oauth_web.py tests/test_google_oauth_web.py`
- `pytest -q` *(fails: test_event_crud)*

------
https://chatgpt.com/codex/tasks/task_e_687ec002262483249a54e0723ead30da