### PR TITLE
Improve OAuth token error reporting

### DIFF
--- a/OAUTH_ERROR_HANDLING.md
+++ b/OAUTH_ERROR_HANDLING.md
@@ -1,0 +1,10 @@
+# OAuth Error Handling Report
+
+This document summarizes updates to error handling for Google OAuth token exchange.
+
+| File/Line | Old Output | New Output |
+|-----------|-----------|-----------|
+| `google_auth.py` L137 | `{"error": "token_failed", "details": text}` | `{"error": "token_failed", "details": text or str(exc)}` |
+| `web/routes/google_oauth_web.py` L94 | `{"error": f"Authentication failed: {exc}", "details": text}` (could be null) | `{"error": f"Authentication failed: {exc}", "details": text or str(exc)}` |
+
+Both locations now log the response status and text and ensure the API response contains the full Google error message. Automated tests check that `details` is never `None`.

--- a/google_auth.py
+++ b/google_auth.py
@@ -134,6 +134,8 @@ def oauth2callback():
             current_app.logger.error("Response status: %s", status)
         if text:
             current_app.logger.error("Response text: %s", text)
+        else:
+            text = str(exc)
         return jsonify({"error": "token_failed", "details": text}), 400
 
     creds = flow.credentials

--- a/tests/test_google_auth.py
+++ b/tests/test_google_auth.py
@@ -234,3 +234,5 @@ def test_oauth2callback_invalid_state_or_token(client, tmp_path, monkeypatch):
 
     resp = client.get("/oauth2callback?state=good&code=x")
     assert resp.status_code == 400
+    assert resp.is_json
+    assert resp.json["details"] == "fail"

--- a/tests/test_google_oauth_web.py
+++ b/tests/test_google_oauth_web.py
@@ -154,7 +154,7 @@ def test_oauth2callback_fetch_failure(tmp_path, monkeypatch):
     assert resp.status_code == 400
     assert resp.is_json
     assert resp.json["error"].startswith("Authentication failed")
-    assert resp.json["details"] is None
+    assert resp.json["details"] == "fail"
 
 
 def test_oauth2callback_save_failure(tmp_path, monkeypatch):

--- a/web/routes/google_oauth_web.py
+++ b/web/routes/google_oauth_web.py
@@ -91,6 +91,8 @@ def oauth2callback() -> Response:
             log.error("Response status: %s", status)
         if text:
             log.error("Response text: %s", text)
+        else:
+            text = str(exc)
         return jsonify({"error": f"Authentication failed: {exc}", "details": text}), 400
 
     creds = flow.credentials


### PR DESCRIPTION
## Summary
- ensure Google OAuth token error responses include the full text
- adjust tests for new behaviour
- document OAuth error handling improvements

## Testing
- `pytest tests/test_google_auth.py::test_oauth2callback_invalid_state_or_token tests/test_google_oauth_web.py::test_oauth2callback_fetch_failure -q`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_687eca4fdfdc8324ba13ec071b54d82f