### PR TITLE
Add ProxyFix middleware for HTTPS awareness

### DIFF
--- a/main_app.py
+++ b/main_app.py
@@ -13,6 +13,7 @@ import threading
 
 from dotenv import load_dotenv
 from flask import Flask, Response, session
+from werkzeug.middleware.proxy_fix import ProxyFix
 from google_auth import google_auth
 import os
 
@@ -32,21 +33,22 @@ app.config["GOOGLE_CALENDAR_SCOPES"] = [
 app.register_blueprint(google_auth, url_prefix="/auth")
 
 # ✅ Korrekt: Agenten-Loader importieren
-from agents.agenten_loader import init_agents
-from agents.scheduler_agent import SchedulerAgent
-from config import Config
+from agents.agenten_loader import init_agents  # noqa: E402
+from agents.scheduler_agent import SchedulerAgent  # noqa: E402
+from config import Config  # noqa: E402
 
 # 🌍 Module
-from database import close_db
-from fur_lang.i18n import t
-from init_db_core import init_db
-from mongo_service import db  # MongoDB-Instanz
-from utils.env_helpers import get_env_bool, get_env_int
-from utils.github_service import fetch_repo_info
-from web import create_app
+from database import close_db  # noqa: E402
+from fur_lang.i18n import t  # noqa: E402
+from init_db_core import init_db  # noqa: E402
+from mongo_service import db  # MongoDB-Instanz  # noqa: E402
+from utils.env_helpers import get_env_bool, get_env_int  # noqa: E402
+from utils.github_service import fetch_repo_info  # noqa: E402
+from web import create_app  # noqa: E402
 
 # Call to create the Flask application instance via factory pattern
 app = create_app()
+app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1)
 app.teardown_appcontext(close_db)
 app.jinja_env.globals.update(t=t)
 app.jinja_env.globals.update(current_lang=lambda: session.get("lang", "de"))

--- a/tests/test_langchain_service.py
+++ b/tests/test_langchain_service.py
@@ -1,6 +1,6 @@
-import types
+import types  # noqa: F401
 
-import pytest
+import pytest  # noqa: F401
 
 import services.langchain_service as mod
 

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 
 from flask import Blueprint, Flask, request, session
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 from config import Config
 from database import close_db
@@ -60,6 +61,7 @@ def create_app() -> Flask:
         template_folder=template_folder,
         static_folder=static_folder,
     )
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1)
     # Ensure a secret key is set for session handling
     app.secret_key = os.environ.get("FLASK_SECRET", "fallback-dev-key")
     app.config.from_object(Config)


### PR DESCRIPTION
## Summary
- fix OAuth proxy handling by adding ProxyFix to the Flask app factory
- wrap the main application with ProxyFix
- silence flake8 warnings in tests and imports

## Testing
- `black --check .`
- `flake8`
- `pytest -q` *(fails: tests/test_event_crud.py::test_create_and_fetch_by_id, tests/test_event_crud.py::test_get_and_delete_by_guild)*

------
https://chatgpt.com/codex/tasks/task_e_687eceb63fd083249951582456738aa9