### PR TITLE
Fix timezone handling for event reminders

### DIFF
--- a/bot/dm_scheduler.py
+++ b/bot/dm_scheduler.py
@@ -54,6 +54,14 @@ async def check_upcoming_events(bot) -> None:
 
 
 def schedule_dm_tasks(bot) -> None:
-    scheduler.add_job(send_daily_dm, "cron", hour=6, minute=0, args=[bot])
+    """Configure DM tasks with a midnight UTC trigger."""
+    scheduler.add_job(
+        send_daily_dm,
+        trigger="cron",
+        hour=0,
+        minute=0,
+        timezone="UTC",
+        args=[bot],
+    )
     scheduler.add_job(check_upcoming_events, "interval", minutes=1, args=[bot])
     scheduler.start()

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -25,6 +25,9 @@
     <form action="{{ url_for('admin.post_weekly_report') }}" method="post">
       <button class="btn btn-glow">📤 {{ t("Wöchentlichen Report posten") }}</button>
     </form>
+    <form action="{{ url_for('admin.send_daily_dms') }}" method="post">
+      <button class="btn btn-glow">📨 Send Daily DMs</button>
+    </form>
   </div>
 
   <div class="panel" style="margin-top: 3rem; max-width: 600px;">
@@ -39,6 +42,21 @@
         <textarea id="message" name="message" rows="4" required></textarea>
       </div>
       <button type="submit" class="btn btn-glow">📣 {{ t("Ankündigung posten") }}</button>
+    </form>
+  </div>
+
+  <div class="panel" style="margin-top: 2rem; max-width: 600px;">
+    <h3>✉️ Send Custom DM</h3>
+    <form action="{{ url_for('admin.send_custom_dm') }}" method="post">
+      <div class="form-row" style="margin-bottom: 0.75rem;">
+        <label for="dm_message">Message</label>
+        <textarea id="dm_message" name="message" rows="3" required></textarea>
+      </div>
+      <div class="form-row" style="margin-bottom: 0.75rem;">
+        <label for="user_id">User ID (optional)</label>
+        <input type="text" id="user_id" name="user_id">
+      </div>
+      <button type="submit" class="btn btn-glow">✉️ Send DM</button>
     </form>
   </div>
 

--- a/tests/test_admin_auth.py
+++ b/tests/test_admin_auth.py
@@ -75,3 +75,15 @@ def test_post_event_requires_r4(client):
     assert resp.status_code == 302
     assert resp.headers["Location"].endswith("/admin/events")
     collection.delete_one({"_id": event_id})
+
+
+def test_send_daily_dms_requires_r4(client):
+    resp = _check_requires_r4(client, "POST", "/admin/send_daily_dms")
+    assert resp.status_code == 200
+    assert resp.data == b"daily"
+
+
+def test_send_custom_dm_requires_r4(client):
+    resp = _check_requires_r4(client, "POST", "/admin/send_custom_dm")
+    assert resp.status_code == 200
+    assert resp.data == b"custom"

--- a/tests/test_dm_scheduler.py
+++ b/tests/test_dm_scheduler.py
@@ -86,7 +86,7 @@ def test_schedule_dm_tasks(monkeypatch):
         running = False
 
         def add_job(self, func, trigger, **kw):
-            jobs.append((func, trigger))
+            jobs.append((func, trigger, kw))
 
         def start(self):
             self.running = True
@@ -98,3 +98,8 @@ def test_schedule_dm_tasks(monkeypatch):
 
     assert fake.running
     assert len(jobs) == 2
+    cron_job = jobs[0]
+    assert cron_job[1] == "cron"
+    assert cron_job[2]["hour"] == 0
+    assert cron_job[2]["minute"] == 0
+    assert cron_job[2]["timezone"] == "UTC"

--- a/tests/test_event_helpers.py
+++ b/tests/test_event_helpers.py
@@ -1,6 +1,8 @@
-from datetime import datetime
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 
 import utils.event_helpers as mod
+
 from fur_lang import i18n
 
 
@@ -22,17 +24,26 @@ class FakeEvents:
 def fake_get_collection(name):
     return FakeEvents(
         [
-            {"title": "A", "event_time": datetime(2025, 1, 1, 10, 0)},
-            {"title": "B", "event_time": datetime(2025, 1, 2, 12, 0)},
+            {"title": "A", "event_time": datetime(2025, 1, 1, 22, 0, tzinfo=timezone.utc)},
+            {"title": "B", "event_time": datetime(2025, 1, 2, 12, 0, tzinfo=timezone.utc)},
         ]
     )
 
 
 def test_get_events_for(monkeypatch):
     monkeypatch.setattr(mod, "get_collection", fake_get_collection)
-    events = mod.get_events_for(datetime(2025, 1, 1))
+    tz = ZoneInfo("Europe/Berlin")
+    events = mod.get_events_for(datetime(2025, 1, 1, 12, 0, tzinfo=tz))
     assert len(events) == 1
     assert events[0]["title"] == "A"
+
+
+def test_get_events_for_tomorrow(monkeypatch):
+    monkeypatch.setattr(mod, "get_collection", fake_get_collection)
+    tz = ZoneInfo("Europe/Berlin")
+    events = mod.get_events_for(datetime(2025, 1, 2, 12, 0, tzinfo=tz))
+    assert len(events) == 1
+    assert events[0]["title"] == "B"
 
 
 def test_format_events(monkeypatch):


### PR DESCRIPTION
## Summary
- compare event dates in Europe/Berlin timezone
- trigger DM scheduler at midnight UTC
- add admin dashboard actions for sending daily and custom DMs
- update tests for new behaviour

## Testing
- `black --check .`
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68801c9d0ba48324a95bcff490dd989b