### PR TITLE
Add DM image config and admin support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,7 @@ ENABLE_DISCORD_BOT=true                # Start Discord bot alongside the app
 REMINDER_DM_DELAY=1                    # Delay in seconds between reminder DMs
 ENABLE_NEWSLETTER_AUTOPILOT=true       # Weekly newsletter sending
 NEWSLETTER_DM_DELAY=1                  # Delay in seconds between newsletter DMs
+DEFAULT_DM_IMAGE_URL=/static/img/dm_default.png   # Fallback DM image
 
 # Google Calendar
 GOOGLE_CALENDAR_ID=                    # Calendar ID (optional)

--- a/config.py
+++ b/config.py
@@ -97,6 +97,9 @@ class Config:
     RESOURCES_FOLDER: str = os.path.join(STATIC_FOLDER, "resources")
     ALLOWED_EXTENSIONS: set[str] = {"jpg", "png"}
     MAX_CONTENT_LENGTH: int = 2 * 1024 * 1024
+    DEFAULT_DM_IMAGE_URL: str = get_env_str(
+        "DEFAULT_DM_IMAGE_URL", default="/static/img/dm_default.png"
+    )
 
     POSTER_OUTPUT_PATH: str = get_env_str(
         "POSTER_OUTPUT_PATH", default=os.path.join(STATIC_FOLDER, "posters")

--- a/schemas/event_schema.py
+++ b/schemas/event_schema.py
@@ -12,7 +12,7 @@ class PyObjectId(ObjectId):
         yield cls.validate
 
     @classmethod
-    def validate(cls, v):
+    def validate(cls, v, *args, **kwargs):
         if isinstance(v, ObjectId):
             return v
         if not ObjectId.is_valid(v):
@@ -32,7 +32,7 @@ class PyObjectId(ObjectId):
 
 # Hauptmodell für Events
 class EventModel(BaseModel):
-    id: Optional[PyObjectId] = Field(alias="_id")
+    id: Optional[PyObjectId] = Field(default=None, alias="_id")
     title: str
     description: Optional[str] = None
     date: str  # ISO-8601 Datum als Text

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -60,6 +60,28 @@
     </form>
   </div>
 
+  <div class="panel" style="margin-top: 2rem; max-width: 600px;">
+    <h3>🖼 DM Images</h3>
+    <form action="{{ url_for('admin.save_dm_images') }}" method="post" enctype="multipart/form-data">
+      <div class="form-row" style="margin-bottom: 0.75rem;">
+        <label for="daily_url">Daily DM Image URL</label>
+        <input type="text" id="daily_url" name="daily_url" value="{{ dm_settings.daily or '' }}">
+        <input type="file" name="daily_file">
+      </div>
+      <div class="form-row" style="margin-bottom: 0.75rem;">
+        <label for="weekly_url">Weekly DM Image URL</label>
+        <input type="text" id="weekly_url" name="weekly_url" value="{{ dm_settings.weekly or '' }}">
+        <input type="file" name="weekly_file">
+      </div>
+      <div class="form-row" style="margin-bottom: 0.75rem;">
+        <label for="custom_url">Custom DM Image URL</label>
+        <input type="text" id="custom_url" name="custom_url" value="{{ dm_settings.custom or '' }}">
+        <input type="file" name="custom_file">
+      </div>
+      <button type="submit" class="btn btn-glow">💾 Save</button>
+    </form>
+  </div>
+
   {% if stats is defined %}
   <div class="panel" style="margin-top:2.5rem; max-width: 600px;">
     <h3>📊 {{ t("Systemstatus") }}</h3>

--- a/tests/test_reminder_optout.py
+++ b/tests/test_reminder_optout.py
@@ -89,4 +89,4 @@ async def test_send_poster_skips_opted_out(monkeypatch):
     cog.bot = bot
     cog.delay = 0
 
-    await autopilot_mod.ReminderAutopilot._send_poster_to_members(cog, "poster")
+    await autopilot_mod.ReminderAutopilot._send_poster_to_members(cog, "poster", "daily")


### PR DESCRIPTION
## Summary
- configure default DM image path in `Config`
- extend admin dashboard to configure images for daily/weekly/custom DMs
- add route to store DM image settings
- embed DM images in scheduler and autopilot
- adjust event schema and tests

## Testing
- `black --check .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6880252e83f88324b9c939e26f504a86