### PR TITLE
Switch to embed URLs for DM and champion images

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,7 @@ REMINDER_ROLE_ID=               # Rolle für Reminder-Mentions
 # === Reminder & Newsletter ===
 ENABLE_CHANNEL_REMINDERS=false   # Reminder in Channel posten
 REMINDER_DM_DELAY=1              # Sekunden zwischen DM-Remindern
+REMINDER_DM_IMAGE_URL=https://fur-martix.up.railway.app/static/img/dm_default.png  # Bild für Reminder-DMs
 ENABLE_NEWSLETTER_AUTOPILOT=true # Wöchentlicher Newsletter
 NEWSLETTER_DM_DELAY=1            # Sekunden zwischen Newsletter-DMs
 

--- a/AI_Intro-Image.json
+++ b/AI_Intro-Image.json
@@ -5,7 +5,7 @@
       "description": "Hello team \ud83d\udc4b\n\nFirst of all, I want to sincerely apologize if I\u2019ve overwhelmed anyone with too many messages or reminders recently \ud83d\ude48 \u2014 that was never the goal. I\u2019ve been upgraded, streamlined, and optimized \u2014 and I appreciate your patience \ud83d\udc99",
       "color": 3447003,
       "thumbnail": {
-        "url": "attachment://SORRY.png"
+        "url": "https://fur-martix.up.railway.app/static/img/SORRY.png"
       },
       "fields": [
         {

--- a/agents/champion_agent.py
+++ b/agents/champion_agent.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 from .poster_agent import PosterAgent
 from .webhook_agent import WebhookAgent
+from config import Config
 
 
 class ChampionAgent:
@@ -16,6 +17,11 @@ class ChampionAgent:
         """Create poster, store entry and optionally send via webhook."""
 
         poster_path = self.poster.create_poster(username, stats)
+        poster_url = (
+            poster_path
+            if poster_path.startswith("http")
+            else Config.BASE_URL.rstrip("/") + "/" + poster_path.lstrip("/")
+        )
         entry = {
             "username": username,
             "month": month,
@@ -24,5 +30,5 @@ class ChampionAgent:
         }
         self.db["hall_of_fame"].insert_one(entry)
         if self.webhook:
-            self.webhook.send_champion_announcement(username, "PvP Champion", month, poster_path)
+            self.webhook.send_champion_announcement(username, "PvP Champion", month, poster_url)
         return poster_path

--- a/agents/poster_agent.py
+++ b/agents/poster_agent.py
@@ -10,7 +10,7 @@ from config import Config
 
 class PosterAgent:
     def __init__(self, output_dir: str | None = None):
-        self.output_dir = Path(output_dir or Config.STATIC_FOLDER) / Config.CHAMPION_OUTPUT_REL_PATH
+        self.output_dir = Path(output_dir or Config.POSTER_OUTPUT_PATH)
         self.output_dir.mkdir(parents=True, exist_ok=True)
 
     def create_poster(self, username: str, stats: str | None = None) -> str:

--- a/agents/webhook_agent.py
+++ b/agents/webhook_agent.py
@@ -17,7 +17,7 @@ class WebhookAgent:
         self,
         content: str,
         webhook_url: Optional[str] = None,
-        file_path: Optional[str] = None,
+        image_url: Optional[str] = None,
         *,
         event_channel: bool = False,
     ) -> bool:
@@ -30,8 +30,8 @@ class WebhookAgent:
         webhook_url:
             Override webhook URL. If ``event_channel`` is ``True`` this is
             ignored.
-        file_path:
-            Optional path to an attachment.
+        image_url:
+            Optional image URL for embed.
         event_channel:
             If ``True`` and ``Config.EVENT_CHANNEL_ID`` is set, the
             message is posted via ``send_discord_message``.
@@ -39,7 +39,7 @@ class WebhookAgent:
 
         if event_channel and Config.EVENT_CHANNEL_ID:
             try:
-                send_discord_message(Config.EVENT_CHANNEL_ID, content, file_path)
+                send_discord_message(Config.EVENT_CHANNEL_ID, content, image_url)
                 logging.info("📤 Event-Channel Nachricht gesendet")
                 return True
             except Exception as e:  # pragma: no cover - network failure
@@ -52,13 +52,11 @@ class WebhookAgent:
             return False
 
         data = {"content": content}
+        if image_url:
+            data["embeds"] = [{"image": {"url": image_url}}]
 
         try:
-            if file_path:
-                with open(file_path, "rb") as fh:
-                    response = requests.post(url, data=data, files={"file": fh})
-            else:
-                response = requests.post(url, data=data)
+            response = requests.post(url, json=data)
             response.raise_for_status()
             logging.info(f"📤 Webhook erfolgreich gesendet ({response.status_code})")
             return True
@@ -70,10 +68,10 @@ class WebhookAgent:
         return self.send(content=f"📘 Neue Log-Datei:\n```{log_content[:1800]}```")
 
     def send_champion_announcement(
-        self, username: str, title: str, month: str, file_path: str
+        self, username: str, title: str, month: str, image_url: str
     ) -> bool:
         message = f"🏆 **{title}**\n{username} wurde Champion im Monat {month}!"
-        return self.send(content=message, file_path=file_path)
+        return self.send(content=message, image_url=image_url)
 
     def send_error(self, context: str, error: Exception) -> bool:
         return self.send(content=f"❌ Fehler in `{context}`:\n```{str(error)}```")

--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -314,8 +314,13 @@ def post_event(event_id: str):
         f"📅 **{event.get('title')}**\n{event.get('description', '')}\n🕒 {event.get('event_time')}"
     )
     webhook = WebhookAgent(Config.DISCORD_WEBHOOK_URL)
-    poster = generate_event_poster(event)
-    success = webhook.send(content, file_path=poster, event_channel=True)
+    poster_path = generate_event_poster(event)
+    poster_url = (
+        poster_path
+        if poster_path.startswith("http")
+        else Config.BASE_URL.rstrip("/") + "/" + poster_path.lstrip("/")
+    )
+    success = webhook.send(content, image_url=poster_url, event_channel=True)
     flash(
         (
             t("event_posted", default="Event posted")

--- a/bot/cogs/intro_cog.py
+++ b/bot/cogs/intro_cog.py
@@ -44,13 +44,12 @@ class IntroCog(commands.Cog):
 
     async def _send_intro(self) -> None:
         embed = self._load_embed()
-        if not embed or not INTRO_IMAGE.is_file():
+        if not embed:
             return
-        file_path = INTRO_IMAGE
         for uid in get_dm_users():
             try:
                 user = await self.bot.fetch_user(uid)
-                await user.send(embed=embed, file=discord.File(file_path))
+                await user.send(embed=embed)
             except Exception as exc:  # noqa: BLE001
                 log.error("intro DM to %s failed: %s", uid, exc)
 

--- a/bot/cogs/reminder_autopilot.py
+++ b/bot/cogs/reminder_autopilot.py
@@ -184,12 +184,15 @@ class ReminderAutopilot(commands.Cog):
             if is_opted_out(member.id):
                 continue
             try:
-                file = discord.File(poster_path)
                 embed = discord.Embed()
                 img = get_dm_image(dm_type)
                 if img:
                     embed.set_thumbnail(url=img)
-                await member.send(file=file, embed=embed)
+                poster_url = poster_path
+                if not poster_url.startswith("http"):
+                    poster_url = Config.BASE_URL.rstrip("/") + "/" + poster_path.lstrip("/")
+                embed.set_image(url=poster_url)
+                await member.send(embed=embed)
                 await asyncio.sleep(self.delay)
             except discord.Forbidden:
                 log.warning("DM blocked for %s", member.id)

--- a/champion/autopilot.py
+++ b/champion/autopilot.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 from champion.webhook import send_discord_webhook
 from utils.champion_data import generate_champion_poster
+from config import Config
 
 
 def run_champion_autopilot(month: Optional[str] = None, username: Optional[str] = None) -> bool:
@@ -28,11 +29,16 @@ def run_champion_autopilot(month: Optional[str] = None, username: Optional[str] 
     username = username or "Champion"
     try:
         poster_path = generate_champion_poster(username)
+        poster_url = (
+            poster_path
+            if poster_path.startswith("http")
+            else Config.BASE_URL.rstrip("/") + "/" + poster_path.lstrip("/")
+        )
         if month:
             content = f"\U0001f3c6 Champion for {month} crowned!"
         else:
             content = "\U0001f3c6 New Champion crowned!"
-        status = send_discord_webhook(content=content, file_path=poster_path)
+        status = send_discord_webhook(content=content, image_url=poster_url)
         if status // 100 != 2:
             logging.warning(
                 "Champion autopilot webhook returned status %s for %s", status, username

--- a/champion/webhook.py
+++ b/champion/webhook.py
@@ -7,15 +7,13 @@ import requests
 from config import Config
 
 
-def send_discord_webhook(content: str, file_path: str) -> int | None:
-    """Upload a file to the configured Discord webhook."""
+def send_discord_webhook(content: str, image_url: str) -> int | None:
+    """Send a Discord webhook with an embed image."""
 
     webhook_url = Config.DISCORD_WEBHOOK_URL
     try:
-        with open(file_path, "rb") as f:
-            files = {"file": f}
-            data = {"content": content}
-            response = requests.post(webhook_url, data=data, files=files)
+        data = {"content": content, "embeds": [{"image": {"url": image_url}}]}
+        response = requests.post(webhook_url, json=data)
         return response.status_code
     except Exception as exc:  # noqa: BLE001
         logging.error("Failed to send Discord webhook: %s", exc)

--- a/config.py
+++ b/config.py
@@ -98,7 +98,8 @@ class Config:
     ALLOWED_EXTENSIONS: set[str] = {"jpg", "png"}
     MAX_CONTENT_LENGTH: int = 2 * 1024 * 1024
     DEFAULT_DM_IMAGE_URL: str = get_env_str(
-        "DEFAULT_DM_IMAGE_URL", default="/static/img/dm_default.png"
+        "DEFAULT_DM_IMAGE_URL",
+        default=f"{os.getenv('BASE_URL', 'http://localhost:8080').rstrip('/')}/static/img/dm_default.png",
     )
 
     POSTER_OUTPUT_PATH: str = get_env_str(

--- a/modules/champion.py
+++ b/modules/champion.py
@@ -17,6 +17,11 @@ def post_champion_poster(username: str = "Champion") -> bool:
         ``True`` if posting succeeded, otherwise ``False``.
     """
     poster_path = generate_champion_poster(username)
+    poster_url = (
+        poster_path
+        if poster_path.startswith("http")
+        else Config.BASE_URL.rstrip("/") + "/" + poster_path.lstrip("/")
+    )
     webhook = WebhookAgent(Config.DISCORD_WEBHOOK_URL)
     content = f"\U0001f3c6 {username} wurde Champion!"
-    return webhook.send(content=content, file_path=poster_path)
+    return webhook.send(content=content, image_url=poster_url)

--- a/tests/test_champion_poster.py
+++ b/tests/test_champion_poster.py
@@ -13,11 +13,12 @@ class DummyResponse:
 def test_generate_poster_and_webhook(monkeypatch, tmp_path):
     # redirect output to temp folder
     monkeypatch.setattr(Config, "STATIC_FOLDER", str(tmp_path))
-    monkeypatch.setattr(Config, "CHAMPION_OUTPUT_REL_PATH", "")
+    monkeypatch.setattr(Config, "POSTER_OUTPUT_PATH", str(tmp_path))
 
     # dummy request.post
-    def fake_post(url, data=None, files=None):
+    def fake_post(url, json=None, **_):
         fake_post.called_url = url
+        assert json and "embeds" in json
         return DummyResponse()
 
     monkeypatch.setattr(webhook.requests, "post", fake_post)
@@ -26,6 +27,6 @@ def test_generate_poster_and_webhook(monkeypatch, tmp_path):
     path = champion_data.generate_champion_poster("Tester")
     assert os.path.isfile(path)
 
-    status = webhook.send_discord_webhook("hello", path)
+    status = webhook.send_discord_webhook("hello", "http://img")
     assert status == 204
     assert fake_post.called_url == "http://example.com"

--- a/tests/test_event_post_message.py
+++ b/tests/test_event_post_message.py
@@ -10,9 +10,9 @@ class FakeWebhook:
         self.url = url
         self.calls = 0
 
-    def send(self, content: str, webhook_url=None, file_path=None, *, event_channel=False):
+    def send(self, content: str, webhook_url=None, image_url=None, *, event_channel=False):
         self.calls += 1
-        assert Path(file_path).is_file()
+        assert image_url.startswith("http")
         return True
 
 

--- a/tests/test_module_champion.py
+++ b/tests/test_module_champion.py
@@ -14,18 +14,18 @@ class FakeWebhook:
         self,
         content: str,
         webhook_url=None,
-        file_path=None,
+        image_url=None,
         *,
         event_channel=False,
     ):
         self.called = True
         self.kwargs = {
             "content": content,
-            "file_path": file_path,
+            "image_url": image_url,
             "event_channel": event_channel,
         }
         # ensure file exists
-        assert file_path and Path(file_path).is_file()
+        assert image_url
         return True
 
 
@@ -52,9 +52,9 @@ def test_run_champion_autopilot(monkeypatch, tmp_path):
         path.write_bytes(b"img")
         return str(path)
 
-    def fake_send(content: str, file_path: str):
+    def fake_send(content: str, image_url: str):
         fake_send.called = True
-        fake_send.kwargs = {"content": content, "file_path": file_path}
+        fake_send.kwargs = {"content": content, "image_url": image_url}
         return 204
 
     monkeypatch.setattr(autopilot_mod, "generate_champion_poster", fake_generate)
@@ -63,7 +63,7 @@ def test_run_champion_autopilot(monkeypatch, tmp_path):
     assert autopilot_mod.run_champion_autopilot(month="June", username="Tester")
     assert fake_send.called
     assert "June" in fake_send.kwargs["content"]
-    assert Path(fake_send.kwargs["file_path"]).exists()
+    assert fake_send.kwargs["image_url"].startswith("http")
 
 
 def test_run_champion_autopilot_error(monkeypatch, tmp_path):

--- a/tests/test_reminder_timings.py
+++ b/tests/test_reminder_timings.py
@@ -168,5 +168,5 @@ async def test_daily_poster_attachment(monkeypatch, tmp_path):
     cog = autopilot_mod.ReminderAutopilot(bot)
     await cog.send_daily_poster()
 
-    assert member.kwargs["file"]["path"] == str(poster_file)
-    assert not member.kwargs.get("content")
+    assert isinstance(member.kwargs.get("embed"), autopilot_mod.discord.Embed)
+    assert member.kwargs["embed"].image.url.endswith("poster.png")

--- a/utils/champion_data.py
+++ b/utils/champion_data.py
@@ -43,7 +43,7 @@ def get_champion_by_month(month: str) -> Optional[Dict[str, str]]:
 def generate_champion_poster(username: str = "Champion") -> str:
     """Generate a simple champion poster image and return file path."""
 
-    output_dir = os.path.join(Config.STATIC_FOLDER, Config.CHAMPION_OUTPUT_REL_PATH)
+    output_dir = Config.POSTER_OUTPUT_PATH
     os.makedirs(output_dir, exist_ok=True)
     file_path = os.path.join(output_dir, f"{uuid.uuid4().hex}.png")
 

--- a/utils/discord_util.py
+++ b/utils/discord_util.py
@@ -20,16 +20,19 @@ if ENABLE_BOT:
     intents = discord.Intents.all()
     bot = commands.Bot(command_prefix="!", intents=intents)
 
-    async def send_discord_message(channel_id: int, content: str, file_path: str = None):
+    async def send_discord_message(
+        channel_id: int, content: str, image_url: str | None = None
+    ) -> None:
         """Sendet eine Nachricht über den echten Discord-Bot."""
         channel = bot.get_channel(channel_id)
         if channel is None:
             logging.warning(f"⚠️ Channel {channel_id} nicht gefunden.")
             return
 
-        if file_path:
-            file = discord.File(file_path)
-            await channel.send(content, file=file)
+        if image_url:
+            embed = discord.Embed()
+            embed.set_image(url=image_url)
+            await channel.send(content, embed=embed)
         else:
             await channel.send(content)
 
@@ -39,15 +42,12 @@ else:
 
     DISCORD_WEBHOOK_URL = os.getenv("DISCORD_WEBHOOK_URL")
 
-    def send_discord_message(channel_id: int, content: str, file_path: str = None):
+    def send_discord_message(channel_id: int, content: str, image_url: str | None = None) -> None:
         """Sendet eine Nachricht via Discord Webhook (ohne Bot)."""
         data = {"content": content}
-        files = None
-
-        if file_path and os.path.exists(file_path):
-            with open(file_path, "rb") as f:
-                files = {"file": (os.path.basename(file_path), f)}
-                response = requests.post(DISCORD_WEBHOOK_URL, data=data, files=files)
+        if image_url:
+            data["embeds"] = [{"image": {"url": image_url}}]
+            response = requests.post(DISCORD_WEBHOOK_URL, json=data)
         else:
             response = requests.post(DISCORD_WEBHOOK_URL, json=data)
 


### PR DESCRIPTION
## Summary
- use BASE_URL for default DM image path and env variable
- load DM images via URL and serve champion posters from `static/posters`
- update reminder autopilot and intro cog for embed URLs
- refactor webhook sending logic to accept `image_url`
- adjust tests for new embed-based behaviour

## Testing
- `black --check .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881d48d7b348324a9d6454a13ad76da