### PR TITLE
Implement calendar poster workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,14 @@ Token Refresh-Flows sind implementiert
 
 Codex blockiert Deployment ohne .env.example + Commit-Lint
 
+## Google Calendar → Eventbild → Discord Workflow
+
+- Liest Events automatisiert aus Google Calendar
+- Erstellt für jedes Event ein ansprechendes Eventbild (FUR-Style)
+- Postet Event + Bild als Embed ins Discord (mit `!postevent`)
+- Vollständig modular, robust und testbar umgesetzt
+- Für Setup siehe `requirements.txt` und API-Doku im Ordner `docs/`
+
 📬 Kontakt
 
 Maintainer: Marcel Schlanzke

--- a/services/calendar_service.py
+++ b/services/calendar_service.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import os
-from datetime import datetime, timedelta, timezone
+from datetime import date as date_type, datetime, timedelta, timezone
 from typing import Any, Iterable, Optional
 
 from flask import current_app
@@ -205,6 +205,23 @@ class CalendarService:
         now = datetime.utcnow().replace(tzinfo=timezone.utc)
         start = now.replace(hour=0, minute=0, second=0, microsecond=0)
         end = start + timedelta(days=7)
+        return await self._get_range(start, end)
+
+    async def get_next_event(self) -> Optional[dict]:
+        """Return the next upcoming event or ``None`` if none found."""
+        now = datetime.utcnow().replace(tzinfo=timezone.utc)
+        window_end = now + timedelta(days=365)
+        events = await self._get_range(now, window_end)
+        return events[0] if events else None
+
+    async def get_events_for_date(self, dt: datetime | date_type) -> list[dict]:
+        """Return events for the given day in UTC."""
+        if isinstance(dt, datetime):
+            day = dt.date()
+        else:
+            day = dt
+        start = datetime.combine(day, datetime.min.time(), timezone.utc)
+        end = start + timedelta(days=1)
         return await self._get_range(start, end)
 
 

--- a/tests/test_calendar_service.py
+++ b/tests/test_calendar_service.py
@@ -3,6 +3,7 @@ import types
 import pytest
 
 import services.calendar_service as mod
+from datetime import datetime, timedelta, timezone, date as date_type
 
 
 class DummyCollection:
@@ -117,3 +118,32 @@ async def test_sync_uses_stored_token(monkeypatch):
     assert captured.get("syncToken") == "old"
     token = await tokens_col.find_one({"_id": "google"})
     assert token["token"] == "new"
+
+
+@pytest.mark.asyncio
+async def test_get_next_event_and_events_for_date(monkeypatch):
+    events_col = DummyCollection()
+    tokens_col = DummyCollection()
+    service = mod.CalendarService(events_collection=events_col, tokens_collection=tokens_col)
+
+    async def fake_get_range(start, end, *, col=None):
+        col = col or events_col
+        result = [d for d in col.docs if start <= d["event_time"] < end]
+        result.sort(key=lambda d: d["event_time"])
+        return result
+
+    monkeypatch.setattr(mod.event_crud, "get_events_in_range", fake_get_range)
+
+    now = datetime.utcnow().replace(tzinfo=timezone.utc)
+    events_col.docs.extend(
+        [
+            {"event_time": now + timedelta(hours=1), "title": "A"},
+            {"event_time": now + timedelta(days=1), "title": "B"},
+        ]
+    )
+
+    ev = await service.get_next_event()
+    assert ev and ev["title"] == "A"
+
+    events = await service.get_events_for_date((now + timedelta(hours=1)).date())
+    assert len(events) == 1 and events[0]["title"] == "A"

--- a/tests/test_poster_generator.py
+++ b/tests/test_poster_generator.py
@@ -2,7 +2,7 @@ import os
 from datetime import datetime
 
 from config import Config
-from utils.poster_generator import generate_event_poster
+from utils.poster_generator import create_event_image, generate_event_poster
 
 
 def test_generate_poster_daily_weekly(monkeypatch, tmp_path):
@@ -15,3 +15,8 @@ def test_generate_poster_daily_weekly(monkeypatch, tmp_path):
 
     path_weekly = generate_event_poster(event, "weekly")
     assert os.path.isfile(path_weekly)
+
+
+def test_create_event_image_bytes(monkeypatch):
+    buf = create_event_image("Test", datetime(2025, 1, 1, 12, 0), "desc")
+    assert isinstance(buf.getvalue(), (bytes, bytearray))


### PR DESCRIPTION
## Summary
- generate event images in-memory via `create_event_image`
- expose helper methods `get_next_event` and `get_events_for_date`
- support posting next event through Discord command
- document calendar→image→Discord workflow
- extend tests for new utils and service helpers

## Testing
- `black --check .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688291c4e29c832482bde449e764e689