### PR TITLE
Document BABEL_DEFAULT_LOCALE

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,7 @@ CODEX_ENV_NODE_VERSION=20        # Node-Version für Codex
 CODEX_ENV_RUST_VERSION=1.87.0    # Rust-Version für Codex
 CODEX_ENV_GO_VERSION=1.23.8      # Go-Version für Codex
 CODEX_ENV_SWIFT_VERSION=6.1      # Swift-Version für Codex
+BABEL_DEFAULT_LOCALE=               # Default locale for Flask-Babel
 
 # === Weitere Pfade & Sonstiges ===
 POSTER_OUTPUT_PATH=static/generated   # Speicherort generierter Poster

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -5,7 +5,7 @@ The following table lists all variables accessed in the codebase. Locations refe
 | Variable | Location (examples) | Purpose |
 |----------|--------------------|---------|
 | ADMIN_ROLE_IDS | config.py, agents/access_agent.py | Discord role IDs with admin privileges |
-| BABEL_DEFAULT_LOCALE | fur_lang/i18n.py | Fallback locale when none set |
+| BABEL_DEFAULT_LOCALE | fur_lang/i18n.py | Default locale for Flask-Babel |
 | BASE_URL | config.py, core/universal/setup.py | Public application base URL |
 | CODEX_ENV_GO_VERSION | core/universal/setup.py | Version hint for Go runtime |
 | CODEX_ENV_NODE_VERSION | core/universal/setup.py | Version hint for Node runtime |


### PR DESCRIPTION
## Summary
- add `BABEL_DEFAULT_LOCALE` entry in `.env.example`
- document BABEL_DEFAULT_LOCALE purpose in `docs/env_vars.md`

## Testing
- `n/a` (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68852ad013908324bda368cc21243c94