### PR TITLE
Add pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.11.0
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-pytest
+    rev: v7.4.3
+    hooks:
+      - id: pytest

--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ cd try
 # 2. Umgebung konfigurieren
 
 cp .env.example .env
-poetry install
+# 3. Pre-commit installieren
 
-# 3. Starten (lokal)
+pre-commit install
+
+# 4. Starten (lokal)
 
 poetry run python main_app.py
 
@@ -95,6 +97,7 @@ Testabdeckung für Agenten, API-Flows, Discord-Kommandos
 Linting: ruff, mypy, black
 
 Pre-Commit Hooks aktiviert (.pre-commit-config.yaml)
+Vor dem ersten Commit: `pre-commit install`
 
 📄 Dokumentation
 


### PR DESCRIPTION
## Summary
- configure `black`, `flake8`, and `pytest` in `.pre-commit-config.yaml`
- document pre-commit installation in README

## Testing
- `black --check .`
- `flake8 .` *(fails: F401 in tests/test_calendar_service.py)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68852c08c9c883248b108de269a5afbc