### PR TITLE
Fix calendar service test import

### DIFF
--- a/tests/test_calendar_service.py
+++ b/tests/test_calendar_service.py
@@ -3,7 +3,7 @@ import types
 import pytest
 
 import services.calendar_service as mod
-from datetime import datetime, timedelta, timezone, date as date_type
+from datetime import datetime, timedelta, timezone
 
 
 class DummyCollection:


### PR DESCRIPTION
## Summary
- remove unused alias from calendar service test

## Testing
- `black --check .`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68852b6145388324aa1f9dec4930938d