### PR TITLE
Add simple guide login

### DIFF
--- a/dashboard/routes.py
+++ b/dashboard/routes.py
@@ -1,7 +1,24 @@
 import os
 from datetime import datetime
 
-from flask import Blueprint, render_template
+from flask import Blueprint, render_template, request, redirect, session, url_for, flash
+
+USERS = {"Burak": "Var", "Marcel": "Mai"}
+
+
+def login_required(func):
+    """Simple login check for dashboard pages."""
+
+    from functools import wraps
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if session.get("dashboard_user") not in USERS:
+            return redirect(url_for("dashboard.login"))
+        return func(*args, **kwargs)
+
+    return wrapper
+
 
 dashboard = Blueprint("dashboard", __name__, url_prefix="/dashboard")
 
@@ -15,3 +32,21 @@ def progress():
         with open(log_path, "r", encoding="utf-8") as f:
             log_content = f.read()
     return render_template("dashboard/progress.html", log_content=log_content)
+
+
+@dashboard.route("/login", methods=["GET", "POST"])
+def login():
+    if request.method == "POST":
+        username = request.form.get("username")
+        password = request.form.get("password")
+        if username in USERS and USERS[username] == password:
+            session["dashboard_user"] = username
+            return redirect(url_for("dashboard.guide"))
+        flash("Invalid credentials", "danger")
+    return render_template("dashboard/login.html")
+
+
+@dashboard.route("/guide")
+@login_required
+def guide():
+    return render_template("dashboard/guide.html")

--- a/templates/dashboard/guide.html
+++ b/templates/dashboard/guide.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Dashboard Guide</title>
+  <style>
+    body {
+      background-color: #0f0f0f;
+      color: #f0f0f0;
+      font-family: 'Courier New', monospace;
+      padding: 30px;
+    }
+    section {
+      background: #1a1a1a;
+      padding: 20px;
+      border-left: 6px solid #ff9900;
+    }
+  </style>
+</head>
+<body>
+  <h1>📖 Dashboard Guide</h1>
+  <section>
+    <p>This space is reserved for sensitive information.</p>
+  </section>
+</body>
+</html>

--- a/templates/dashboard/login.html
+++ b/templates/dashboard/login.html
@@ -1,0 +1,17 @@
+{% extends "layout.html" %}
+{% block title %}Dashboard Login{% endblock %}
+{% block content %}
+  <div class="main-content" style="max-width:400px;margin:2rem auto;">
+    <form method="post">
+      <div class="form-row" style="margin-bottom:0.75rem;">
+        <label for="username">Username</label>
+        <input type="text" id="username" name="username" required>
+      </div>
+      <div class="form-row" style="margin-bottom:0.75rem;">
+        <label for="password">Password</label>
+        <input type="password" id="password" name="password" required>
+      </div>
+      <button type="submit" class="btn">Login</button>
+    </form>
+  </div>
+{% endblock %}

--- a/tests/test_dashboard_login.py
+++ b/tests/test_dashboard_login.py
@@ -1,0 +1,18 @@
+def test_dashboard_guide_requires_login(client):
+    resp = client.get("/dashboard/guide")
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/dashboard/login")
+
+
+def test_dashboard_login_success(client):
+    resp = client.post(
+        "/dashboard/login",
+        data={"username": "Burak", "password": "Var"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/dashboard/guide")
+    # subsequent access should succeed
+    resp = client.get("/dashboard/guide")
+    assert resp.status_code == 200
+    assert b"Dashboard Guide" in resp.data


### PR DESCRIPTION
## Summary
- create dashboard login form and guide page
- gate dashboard guide behind login check
- ensure unauthorized access redirects to login
- test the new login flow

## Testing
- `black --check dashboard/routes.py tests/test_dashboard_login.py`
- `flake8 dashboard/routes.py tests/test_dashboard_login.py`
- `pytest -q tests/test_dashboard_login.py`


------
https://chatgpt.com/codex/tasks/task_e_68852e77a23c8324917864ed49564e84