### PR TITLE
Add script to enable Codex autopilot daily log

### DIFF
--- a/activate_codex_autopilot.py
+++ b/activate_codex_autopilot.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from mongo_service import get_collection  # noqa: E402
+
+
+def enable_codex_autopilot() -> None:
+    """Enable daily log write monitoring in the codex settings."""
+    collection = get_collection("codex_settings")
+    collection.update_one(
+        {"module": "codex_autopilot"},
+        {
+            "$set": {
+                "enabled": True,
+                "last_activated": datetime.utcnow().isoformat(),
+                "mode": "daily_log_write",
+                "target": "write_log_to_mongo",
+                "trigger": "daily",
+            }
+        },
+        upsert=True,
+    )
+    print("✅ Codex Autopilot-Modus aktiviert – tägliche Write Logs werden überwacht.")
+
+
+if __name__ == "__main__":
+    enable_codex_autopilot()


### PR DESCRIPTION
## Summary
- add standalone script to enable Codex autopilot and monitor daily log writes

## Testing
- `black --check activate_codex_autopilot.py`
- `flake8`
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask_socketio')*

------
https://chatgpt.com/codex/tasks/task_e_688e0f2812d08324aae476e34c915c19