### PR TITLE
Add validation and logging to InboxAgent

### DIFF
--- a/agents/inbox_agent.py
+++ b/agents/inbox_agent.py
@@ -1,18 +1,55 @@
 """Simple inbox handler for Discord DMs and feedback messages."""
 
 from datetime import datetime
+import logging
+from pymongo.errors import PyMongoError
+
+
+log = logging.getLogger(__name__)
 
 
 class InboxAgent:
+    """Persist incoming messages to the inbox collection."""
+
     def __init__(self, db):
         self.db = db
 
     def receive_message(self, discord_id: str, content: str):
-        self.db["inbox"].insert_one(
-            {
-                "discord_id": discord_id,
-                "message": content,
-                "timestamp": datetime.utcnow(),
-            }
-        )
+        """Store a message from a Discord user.
+
+        Parameters
+        ----------
+        discord_id: str
+            Identifier of the Discord user sending the message.
+        content: str
+            Text content of the message.
+
+        Returns
+        -------
+        str
+            Confirmation message for the user.
+
+        Raises
+        ------
+        ValueError
+            If ``content`` is empty.
+        PyMongoError
+            If the database operation fails.
+        """
+
+        if not content:
+            raise ValueError("content must not be empty")
+
+        try:
+            self.db["inbox"].insert_one(
+                {
+                    "discord_id": discord_id,
+                    "message": content,
+                    "timestamp": datetime.utcnow(),
+                }
+            )
+        except PyMongoError:
+            log.exception("Failed to store message for %s", discord_id)
+            raise
+
         return "📥 Nachricht empfangen – danke für dein Feedback!"

--- a/init_daily_logs.py
+++ b/init_daily_logs.py
@@ -27,12 +27,10 @@ log_entry = {
     "date": datetime.now().strftime("%Y-%m-%d"),
     "type": "project_log",
     "entries": [
-        {"category": "FUR SYSTEM",
-         "content": "daily_logs wurde erfolgreich initialisiert."},
-        {"category": "Codex",
-         "content": "Export zu GitHub folgt im nächsten Schritt."}
+        {"category": "FUR SYSTEM", "content": "daily_logs wurde erfolgreich initialisiert."},
+        {"category": "Codex", "content": "Export zu GitHub folgt im nächsten Schritt."},
     ],
-    "created_by": "Mai Diep Anh Do"
+    "created_by": "Mai Diep Anh Do",
 }
 
 # Eintrag speichern


### PR DESCRIPTION
## Summary
- document InboxAgent and its receive_message method
- validate non-empty content and log database errors

## Testing
- `black --check .`
- `flake8`
- `pytest` (fails: 20 errors during collection)

------
https://chatgpt.com/codex/tasks/task_e_688e4417bdc08324b42c936ba3ed51c7