### PR TITLE
Add InboxAgent Mongo insert test

### DIFF
--- a/tests/test_inbox_agent.py
+++ b/tests/test_inbox_agent.py
@@ -1,0 +1,21 @@
+import mongomock
+from agents.inbox_agent import InboxAgent
+from datetime import datetime
+
+
+def test_receive_message_stores_document():
+    client = mongomock.MongoClient()
+    db = client["testdb"]
+    agent = InboxAgent(db)
+
+    discord_id = "12345"
+    content = "Hello there"
+
+    agent.receive_message(discord_id, content)
+
+    doc = db["inbox"].find_one({"discord_id": discord_id})
+    assert doc is not None
+    assert doc["discord_id"] == discord_id
+    assert doc["message"] == content
+    assert "timestamp" in doc
+    assert isinstance(doc["timestamp"], datetime)


### PR DESCRIPTION
## Summary
- test InboxAgent.receive_message stores discord id, message and timestamp in Mongo

## Testing
- `python -m black --check tests/test_inbox_agent.py`
- `flake8`
- `pytest` (fails: tests/test_dashboard_login.py::test_dashboard_login_success)
- `pytest tests/test_inbox_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_688e4420653c8324a139326b4bc86cb3