### PR TITLE
Centralize calendar datetime parsing and add tests

### DIFF
--- a/google_calendar_sync.py
+++ b/google_calendar_sync.py
@@ -11,6 +11,7 @@ from googleapiclient.discovery import build
 
 from config import Config
 from mongo_service import get_collection
+from utils.time_utils import parse_calendar_datetime
 
 # Logging setup
 LOG_PATH = Path("logs")
@@ -102,26 +103,6 @@ def get_calendar_service():
         return None
 
 
-def _parse_datetime(info: Optional[dict]) -> Optional[datetime]:
-    if not info:
-        return None
-    value = info.get("dateTime") or info.get("date")
-    if not value:
-        return None
-    if value.endswith("Z"):
-        value = value.replace("Z", "+00:00")
-    try:
-        dt = datetime.fromisoformat(value)
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        else:
-            dt = dt.astimezone(timezone.utc)
-        return dt
-    except ValueError:
-        logger.warning("Could not parse datetime: %s", value)
-        return None
-
-
 def fetch_upcoming_events(
     service: Any | None = None,
     *,
@@ -167,8 +148,8 @@ def fetch_upcoming_events(
 
 
 def _build_doc(event: dict) -> dict:
-    start_dt = _parse_datetime(event.get("start"))
-    end_dt = _parse_datetime(event.get("end"))
+    start_dt = parse_calendar_datetime(event.get("start"))
+    end_dt = parse_calendar_datetime(event.get("end"))
     return {
         "google_id": event.get("id"),
         "title": event.get("summary", "No Title"),

--- a/init_daily_logs.py
+++ b/init_daily_logs.py
@@ -27,12 +27,10 @@ log_entry = {
     "date": datetime.now().strftime("%Y-%m-%d"),
     "type": "project_log",
     "entries": [
-        {"category": "FUR SYSTEM",
-         "content": "daily_logs wurde erfolgreich initialisiert."},
-        {"category": "Codex",
-         "content": "Export zu GitHub folgt im nächsten Schritt."}
+        {"category": "FUR SYSTEM", "content": "daily_logs wurde erfolgreich initialisiert."},
+        {"category": "Codex", "content": "Export zu GitHub folgt im nächsten Schritt."},
     ],
-    "created_by": "Mai Diep Anh Do"
+    "created_by": "Mai Diep Anh Do",
 }
 
 # Eintrag speichern

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -1,0 +1,15 @@
+from datetime import datetime, timezone
+
+from utils.time_utils import parse_calendar_datetime
+
+
+def test_parse_calendar_datetime_with_datetime():
+    info = {"dateTime": "2025-01-01T12:00:00-05:00"}
+    parsed = parse_calendar_datetime(info)
+    assert parsed == datetime(2025, 1, 1, 17, 0, tzinfo=timezone.utc)
+
+
+def test_parse_calendar_datetime_with_date():
+    info = {"date": "2025-01-01"}
+    parsed = parse_calendar_datetime(info)
+    assert parsed == datetime(2025, 1, 1, tzinfo=timezone.utc)

--- a/utils/time_utils.py
+++ b/utils/time_utils.py
@@ -1,0 +1,48 @@
+"""Utility helpers for working with calendar datetimes."""
+
+from datetime import datetime, timezone
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def parse_calendar_datetime(info: dict | None) -> datetime | None:
+    """Parse Google Calendar date or datetime dict into UTC ``datetime``.
+
+    The Google Calendar API returns event start/end times either under the
+    ``dateTime`` key for timed events or ``date`` for all-day events. This
+    helper normalizes both formats to a timezone-aware UTC ``datetime``.
+
+    Parameters
+    ----------
+    info:
+        Mapping from the Calendar API containing either ``dateTime`` or
+        ``date``.
+
+    Returns
+    -------
+    datetime | None
+        A timezone-aware UTC ``datetime`` instance or ``None`` when the
+        input could not be parsed.
+    """
+
+    if not info:
+        return None
+    value = info.get("dateTime") or info.get("date")
+    if not value:
+        return None
+    if value.endswith("Z"):
+        value = value.replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(value)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        else:
+            dt = dt.astimezone(timezone.utc)
+        return dt
+    except ValueError:
+        log.warning("Could not parse datetime: %s", value)
+        return None
+
+
+__all__ = ["parse_calendar_datetime"]


### PR DESCRIPTION
## Summary
- add `parse_calendar_datetime` helper
- reuse helper in calendar sync modules
- cover date and datetime parsing with unit tests

## Testing
- `black --check .`
- `flake8`
- `PYTHONPATH=/workspace/try pytest /tmp/test_time_utils.py -q`
- `PYTHONPATH=/workspace/try pytest /tmp/test_timezone.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688e4441aad4832489009ed8b41fd22b