### PR TITLE
feat: cache DM reminders and log errors

### DIFF
--- a/tests/test_dm_reminder_scheduler.py
+++ b/tests/test_dm_reminder_scheduler.py
@@ -1,0 +1,67 @@
+from datetime import datetime, timezone
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_avoids_duplicate_dms(monkeypatch):
+    from services import calendar_service as mod
+
+    # prevent background task from starting
+    monkeypatch.setattr(mod.tasks.Loop, "start", lambda self, *a, **k: None)
+
+    class FakeUser:
+        def __init__(self, uid, recorder):
+            self.id = uid
+            self.recorder = recorder
+
+        async def send(self, msg):
+            self.recorder.append((self.id, msg))
+
+    class FakeBot:
+        def __init__(self):
+            self.sent = []
+
+        async def wait_until_ready(self):
+            return None
+
+        async def fetch_user(self, uid):
+            return FakeUser(uid, self.sent)
+
+    class FakeParticipants:
+        def __init__(self):
+            self.docs = [{"user_id": "1"}]
+
+        def find(self, query):
+            return self
+
+        async def to_list(self, length=None):
+            return self.docs
+
+    class FakeEventsCollection:
+        def __init__(self):
+            self.database = {"event_participants": FakeParticipants()}
+
+    class FakeService:
+        def __init__(self):
+            self.events = FakeEventsCollection()
+
+        async def _get_range(self, start, end):
+            return [
+                {
+                    "_id": 99,
+                    "title": "Test Event",
+                    "event_time": datetime.utcnow().replace(tzinfo=timezone.utc),
+                }
+            ]
+
+    bot = FakeBot()
+    service = FakeService()
+
+    scheduler = mod.DMReminderScheduler(bot, service)
+
+    # run twice; second should be skipped due to cache
+    await scheduler.reminder_loop()
+    await scheduler.reminder_loop()
+
+    assert len(bot.sent) == 1


### PR DESCRIPTION
## Summary
- prevent duplicate DM reminders with in-memory cache
- add detailed logging and error handling around DM sends
- add unit test ensuring duplicate reminders are skipped

## Testing
- `black --check services/calendar_service.py tests/test_dm_reminder_scheduler.py`
- `flake8`
- `pytest` *(fails: tests/test_dashboard_login.py::test_dashboard_login_success)*


------
https://chatgpt.com/codex/tasks/task_e_688e444b86ec8324b13e7c30c58c9953