### PR TITLE
Refactor app initialization to use factory

### DIFF
--- a/main_app.py
+++ b/main_app.py
@@ -12,25 +12,8 @@ import sys
 import threading
 
 from dotenv import load_dotenv
-from flask import Flask, Response, session
+from flask import Response, session
 from werkzeug.middleware.proxy_fix import ProxyFix
-from google_auth import google_auth
-import os
-
-# === Flask App erstellen ===
-# Initialize the Flask app instance
-app = Flask(__name__)
-app.secret_key = os.environ.get("FLASK_SECRET", "dev-key")
-
-app.config["GOOGLE_CLIENT_CONFIG"] = os.environ.get("GOOGLE_CLIENT_CONFIG")
-app.config["GOOGLE_REDIRECT_URI"] = os.environ.get("GOOGLE_REDIRECT_URI")
-app.config["GOOGLE_CALENDAR_SCOPES"] = [
-    "https://www.googleapis.com/auth/calendar",
-    "https://www.googleapis.com/auth/calendar.readonly",
-]
-
-# Register blueprints for OAuth
-app.register_blueprint(google_auth, url_prefix="/auth")
 
 # ✅ Korrekt: Agenten-Loader importieren
 from agents.agenten_loader import init_agents  # noqa: E402


### PR DESCRIPTION
## Summary
- remove duplicate Flask app setup in `main_app.py`
- invoke `create_app()` directly and configure globals afterward
- ensure `google_auth` blueprint is only registered inside `create_app`

## Testing
- `black --check .` (fails: would reformat init_daily_logs.py)
- `flake8`
- `pytest` (fails: 20 errors during collection)


------
https://chatgpt.com/codex/tasks/task_e_688e44e14d248324a4f4af713747d7c2