### PR TITLE
Improve agent docstrings and clarify bot readiness

### DIFF
--- a/agents/access_agent.py
+++ b/agents/access_agent.py
@@ -13,7 +13,10 @@ class AccessAgent:
         self.r3_roles = set(os.getenv("R3_ROLE_IDS", "").split(","))
 
     def get_user_role_level(self, discord_roles: list[str]) -> str:
-        """Bestimme die höchste Rollenstufe anhand der Discord-Rollenliste"""
+        """Bestimme die höchste Rollenstufe anhand der Discord-Rollenliste.
+
+        Gibt die Rolle mit dem höchsten Berechtigungsniveau zurück.
+        """
         if set(discord_roles) & self.admin_roles:
             return "admin"
         elif set(discord_roles) & self.r4_roles:
@@ -23,7 +26,10 @@ class AccessAgent:
         return "guest"
 
     def log_access(self, discord_id: str, action: str, result: str):
-        """Speichert einen Audit-Log über den Rollencheck"""
+        """Speichert einen Audit-Log über den Rollencheck.
+
+        Persistiert Discord-ID, Aktion, Ergebnis und Zeitpunkt in der Datenbank.
+        """
         self.db["access_logs"].insert_one(
             {
                 "discord_id": discord_id,

--- a/agents/monitoring_agent.py
+++ b/agents/monitoring_agent.py
@@ -15,7 +15,10 @@ class MonitoringAgent:
         self.last_response = None
 
     def check_system(self) -> bool:
-        """Führt einen Healthcheck durch und cached das Ergebnis"""
+        """Führt einen Healthcheck durch und cached das Ergebnis.
+
+        Speichert Zeitstempel, Status und Antworttext des Health-Endpunkts.
+        """
         try:
             response = requests.get(self.health_url, timeout=self.timeout)
             self.last_check = datetime.utcnow()
@@ -31,7 +34,10 @@ class MonitoringAgent:
             return False
 
     def get_status(self) -> dict:
-        """Liefert den aktuellen Status als Dictionary"""
+        """Liefert den aktuellen Status als Dictionary.
+
+        Beinhaltet Zeitstempel, Statusflag und Rohantwort.
+        """
         return {
             "checked_at": self.last_check,
             "status_ok": self.last_status,

--- a/bot/bot_main.py
+++ b/bot/bot_main.py
@@ -119,7 +119,10 @@ async def run_bot(max_retries: int = 3) -> None:
 
 
 def is_ready() -> bool:
-    """Statusprüfung – ist der Bot bereit?"""
+    """Prüft, ob der Bot bereit ist.
+
+    Gibt ``True`` zurück, wenn das Bot-Objekt initialisiert und einsatzbereit ist.
+    """
     return bot is not None and getattr(bot, "is_ready", lambda: False)()
 
 


### PR DESCRIPTION
## Summary
- refine AccessAgent docstrings with full-sentence summaries and additional context
- expand MonitoringAgent docstrings and clarify bot readiness helper

## Testing
- `black --check .` *(fails: would reformat init_daily_logs.py)*
- `flake8`
- `pytest` *(fails: 20 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688e450465748324a49ff466e0db877d