### PR TITLE
Add docstrings and update calendar datetime tests

### DIFF
--- a/google_calendar_sync.py
+++ b/google_calendar_sync.py
@@ -46,6 +46,13 @@ def _get_token_collection():
 
 
 def _load_sync_token() -> str | None:
+    """Fetch the previously stored sync token.
+
+    Returns
+    -------
+    str | None
+        The last sync token from MongoDB or ``None`` when not available.
+    """
     col = _get_token_collection()
     if not hasattr(col, "find_one"):
         return None
@@ -54,6 +61,18 @@ def _load_sync_token() -> str | None:
 
 
 def _store_sync_token(token: str) -> None:
+    """Persist a sync token for later incremental synchronization.
+
+    Parameters
+    ----------
+    token:
+        The sync token returned by the Google Calendar API.
+
+    Returns
+    -------
+    None
+        This function stores the token and does not return a value.
+    """
     col = _get_token_collection()
     if hasattr(col, "update_one"):
         col.update_one({"_id": "google"}, {"$set": {"token": token}}, upsert=True)
@@ -161,6 +180,18 @@ def fetch_upcoming_events(
 
 
 def _build_doc(event: dict) -> dict:
+    """Build a MongoDB document representation for a calendar event.
+
+    Parameters
+    ----------
+    event:
+        Raw event data from the Google Calendar API.
+
+    Returns
+    -------
+    dict
+        Document compatible with the ``calendar_events`` collection.
+    """
     start_dt = parse_calendar_datetime(event.get("start"))
     end_dt = parse_calendar_datetime(event.get("end"))
     return {

--- a/tests/test_google_calendar_sync.py
+++ b/tests/test_google_calendar_sync.py
@@ -7,20 +7,20 @@ import pytest
 import google_calendar_sync as mod
 
 
-def test_parse_datetime_valid_datetime():
-    dt = mod._parse_datetime({"dateTime": "2024-05-10T12:30:00Z"})
+def test_parse_calendar_datetime_valid_datetime():
+    dt = mod.parse_calendar_datetime({"dateTime": "2024-05-10T12:30:00Z"})
     assert dt == datetime(2024, 5, 10, 12, 30, tzinfo=timezone.utc)
 
 
-def test_parse_datetime_valid_date():
-    dt = mod._parse_datetime({"date": "2024-05-10"})
+def test_parse_calendar_datetime_valid_date():
+    dt = mod.parse_calendar_datetime({"date": "2024-05-10"})
     assert dt == datetime(2024, 5, 10, 0, 0, tzinfo=timezone.utc)
 
 
 @pytest.mark.parametrize("info", [None, {}, {"dateTime": "invalid"}])
-def test_parse_datetime_invalid(info, caplog):
-    with caplog.at_level(logging.WARNING):
-        assert mod._parse_datetime(info) is None
+def test_parse_calendar_datetime_invalid(info, caplog):
+    with caplog.at_level(logging.WARNING, logger="utils.time_utils"):
+        assert mod.parse_calendar_datetime(info) is None
 
 
 def test_fetch_upcoming_events(monkeypatch):


### PR DESCRIPTION
## Summary
- document internal calendar sync helpers
- update Google Calendar sync tests to use `parse_calendar_datetime`

## Testing
- `black --check .` *(fails: cannot parse google_auth.py)*
- `flake8` *(fails: google_auth.py:182 SyntaxError: unterminated string literal)*
- `pytest tests/test_google_calendar_sync.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_688e55df2d048324a4b3697665f6e150