### PR TITLE
Add docstring for agent loader

### DIFF
--- a/agents/agenten_loader.py
+++ b/agents/agenten_loader.py
@@ -2,14 +2,32 @@
 agenten_loader.py – Initialisiert alle FUR Agenten zentral
 """
 
+from typing import Any, Mapping
+
 from agents.auth_agent import AuthAgent
 from agents.champion_agent import ChampionAgent
 from agents.log_agent import LogAgent
 from agents.reminder_agent import ReminderAgent
 from agents.translation_agent import TranslationAgent
 
+Agent = Any
 
-def init_agents(db, session=None):
+
+def init_agents(db: Any, session: Mapping | None = None) -> dict[str, "Agent"]:
+    """Initialisiert alle registrierten Agenten und gibt sie gebündelt zurück.
+
+    Zweck:
+        Bündelt die wichtigsten FUR Agenten und macht sie zentral verfügbar.
+
+    Parameter:
+        db (Any): Datenbankschnittstelle, die den Agenten übergeben wird.
+        session (Mapping | None, optional): Optionale Session für Authentifizierung.
+
+    Rückgabewert:
+        dict[str, Agent]: Wörterbuch mit Agentnamen als Schlüssel und den
+        jeweiligen Agent-Instanzen als Werte.
+    """
+
     return {
         "reminder": ReminderAgent(db),
         "translation": TranslationAgent(),


### PR DESCRIPTION
## Summary
- document purpose and return values of `init_agents`

## Testing
- `black --check .` *(fails: cannot parse google_auth.py)*
- `flake8` *(fails: SyntaxError in google_auth.py)*
- `pytest` *(fails: 21 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688e55ee91e48324945a920c47498a46