### PR TITLE
Add auth blueprint and migrate Discord OAuth

### DIFF
--- a/blueprints/public.py
+++ b/blueprints/public.py
@@ -1,7 +1,3 @@
-import secrets
-from urllib.parse import urlencode
-
-import requests
 from bson import ObjectId
 from flask import (
     Blueprint,
@@ -33,136 +29,6 @@ def set_language():
     if lang in get_supported_languages():
         session["lang"] = lang
     return redirect(request.referrer or url_for("public.landing"))
-
-
-@public.route("/login")
-def login():
-    user = session.get("user")
-    if user:
-        role = user.get("role_level")
-        if role in ["ADMIN", "R4"]:
-            return redirect(url_for("admin.dashboard"))
-        elif role == "R3":
-            return redirect(url_for("member.dashboard"))
-    return render_template("public/login.html")
-
-
-@public.route("/logout")
-def logout():
-    session.clear()
-    flash(t("logout_success", default="Logged out successfully."), "info")
-    return redirect(url_for("public.login"))
-
-
-@public.route("/login/discord")
-def discord_login():
-    client_id = current_app.config["DISCORD_CLIENT_ID"]
-    redirect_uri = current_app.config["DISCORD_REDIRECT_URI"]
-
-    state = secrets.token_urlsafe(16)
-    session["discord_oauth_state"] = state
-
-    params = {
-        "client_id": client_id,
-        "redirect_uri": redirect_uri,
-        "response_type": "code",
-        "scope": "identify guilds guilds.members.read",
-        "state": state,
-    }
-
-    url = f"https://discord.com/oauth2/authorize?{urlencode(params)}"
-    return redirect(url)
-
-
-@public.route("/callback")
-def discord_callback():
-    code = request.args.get("code")
-    state = request.args.get("state")
-
-    if not code:
-        return t("missing_code", default="Missing OAuth code."), 400
-    if not state or state != session.pop("discord_oauth_state", None):
-        return t("invalid_oauth_state", default="Invalid OAuth state."), 400
-
-    token_res = requests.post(
-        "https://discord.com/api/oauth2/token",
-        data={
-            "client_id": current_app.config["DISCORD_CLIENT_ID"],
-            "client_secret": current_app.config["DISCORD_CLIENT_SECRET"],
-            "grant_type": "authorization_code",
-            "code": code,
-            "redirect_uri": current_app.config["DISCORD_REDIRECT_URI"],
-        },
-        headers={"Content-Type": "application/x-www-form-urlencoded"},
-        timeout=10,
-    )
-
-    if token_res.status_code != 200:
-        current_app.logger.error("OAuth Token Error %s: %s", token_res.status_code, token_res.text)
-        flash(t("discord_login_failed", default="Discord login failed"), "danger")
-        return redirect(url_for("public.login"))
-
-    access_token = token_res.json().get("access_token")
-
-    user_res = requests.get(
-        "https://discord.com/api/users/@me",
-        headers={"Authorization": f"Bearer {access_token}"},
-    )
-    user_data = user_res.json()
-
-    guild_res = requests.get(
-        f"https://discord.com/api/users/@me/guilds/{current_app.config['DISCORD_GUILD_ID']}/member",
-        headers={"Authorization": f"Bearer {access_token}"},
-    )
-    if guild_res.status_code != 200:
-        return t("guild_membership_required", default="Not a member of the FUR Discord server"), 403
-
-    guild_member = guild_res.json()
-    user_roles = set(str(role) for role in guild_member.get("roles", []))
-
-    r3_roles = set(map(str, current_app.config.get("R3_ROLE_IDS", set())))
-    r4_roles = set(map(str, current_app.config.get("R4_ROLE_IDS", set())))
-    admin_roles = set(map(str, current_app.config.get("ADMIN_ROLE_IDS", set())))
-
-    if user_roles & admin_roles:
-        role_level = "ADMIN"
-    elif user_roles & r4_roles:
-        role_level = "R4"
-    elif user_roles & r3_roles:
-        role_level = "R3"
-    else:
-        current_app.logger.warning("❌ Invalid Discord role")
-        return t("invalid_role", default="Invalid role for access"), 403
-
-    session["discord_roles"] = [role_level]
-    session["user"] = {
-        "id": user_data["id"],
-        "username": user_data["username"],
-        "avatar": user_data["avatar"],
-        "email": user_data.get("email"),
-        "role_level": role_level,
-    }
-    session.permanent = True
-
-    get_collection("users").update_one(
-        {"discord_id": user_data["id"]},
-        {
-            "$set": {
-                "username": user_data["username"],
-                "avatar": user_data["avatar"],
-                "email": user_data.get("email"),
-                "role_level": role_level,
-            }
-        },
-        upsert=True,
-    )
-
-    flash(t("discord_login_success", default="Successfully logged in with Discord"), "success")
-
-    if role_level in ["ADMIN", "R4"]:
-        return redirect(url_for("admin.dashboard"))
-    else:
-        return redirect(url_for("member.dashboard"))
 
 
 @public.route("/lore")
@@ -201,9 +67,9 @@ def view_event(event_id):
 @public.route("/events/<event_id>/join", methods=["POST"])
 @r3_required
 def join_event(event_id):
-    if "user" not in session:
+    if "discord_user" not in session:
         flash(t("login_required", default="Login required."), "warning")
-        return redirect(url_for("public.login"))
+        return redirect(url_for("auth.login"))
 
     flash(t("event_join_success", default="Successfully joined the event!"), "success")
     return redirect(url_for("public.view_event", event_id=event_id))
@@ -239,8 +105,3 @@ def leaderboard():
 def bank_war_top5():
     """Display BANK WAR recap and top 5 players."""
     return render_template("public/bank_war_top5.html")
-
-
-@public.route("/dashboard")
-def dashboard():
-    return render_template("public/dashboard.html")

--- a/templates/public/events.html
+++ b/templates/public/events.html
@@ -18,7 +18,7 @@
           <th>📝 {{ t("Titel") }}</th>
           <th>📄 {{ t("Beschreibung") }}</th>
           <th>🗓️ {{ t("Datum") }}</th>
-          {% if session.get("user") %}
+          {% if session.get("discord_user") %}
             <th>⚙️ {{ t("Aktionen") }}</th>
           {% endif %}
         </tr>
@@ -30,7 +30,7 @@
             <td>{{ event.title }}</td>
             <td>{{ event.description[:80] }}{% if event.description|length > 80 %}...{% endif %}</td>
             <td>{{ event.event_time }}</td>
-            {% if session.get("user") %}
+            {% if session.get("discord_user") %}
               <td>
                 <form action="{{ url_for('public.join_event', event_id=event.id) }}" method="POST" style="display:inline;">
                   <button type="submit" class="btn btn-small">🎟️ {{ t("Beitreten") }}</button>

--- a/templates/public/events_list.html
+++ b/templates/public/events_list.html
@@ -16,7 +16,7 @@
           <th>📝 {{ t("Titel") }}</th>
           <th>📄 {{ t("Beschreibung") }}</th>
           <th>🕒 {{ t("Datum & Uhrzeit") }}</th>
-          {% if session.get("user") %}
+          {% if session.get("discord_user") %}
             <th>🎟️ {{ t("Aktion") }}</th>
           {% endif %}
         </tr>
@@ -28,7 +28,7 @@
               <td>{{ event.title }}</td>
               <td>{{ event.description[:80] }}{% if event.description|length > 80 %}…{% endif %}</td>
               <td>{{ event.event_time }}</td>
-              {% if session.get("user") %}
+              {% if session.get("discord_user") %}
                 <td>
                   <form action="{{ url_for('public.join_event', event_id=event.id) }}" method="POST" style="display:inline;">
                     <button type="submit" class="btn btn-small">➕ {{ t("Beitreten") }}</button>

--- a/templates/public/index.html
+++ b/templates/public/index.html
@@ -8,6 +8,6 @@
   <div style="text-align: center; margin-top: 2em;">
     <h1>🐺 {{ t('welcome_message') }}</h1>
     <p>{{ t('portal_intro') }}</p>
-    <a class="btn" href="{{ url_for('public.discord_login') }}">{{ t('login_with_discord') }}</a>
+    <a class="btn" href="{{ url_for('auth.login') }}">{{ t('login_with_discord') }}</a>
   </div>
 {% endblock %}

--- a/templates/public/landing.html
+++ b/templates/public/landing.html
@@ -8,6 +8,6 @@
     <img src="{{ url_for('static', filename='img/logo.png') }}" alt="FUR Logo" style="max-width: 200px; margin-bottom: 1em;">
     <h1>🐺 {{ t("welcome_message") }}</h1>
     <p>{{ t("portal_intro") }}</p>
-    <a class="btn" href="{{ url_for('public.discord_login') }}">{{ t("login_with_discord") }}</a>
+    <a class="btn" href="{{ url_for('auth.login') }}">{{ t("login_with_discord") }}</a>
   </div>
 {% endblock %}

--- a/templates/public/login.html
+++ b/templates/public/login.html
@@ -7,6 +7,6 @@
 {% block content %}
   <div style="text-align: center; margin-top: 3em;">
     <h2>{{ t("login_required") }}</h2>
-    <a class="btn" href="{{ url_for('public.discord_login') }}">{{ t("login_with_discord") }}</a>
+    <a class="btn" href="{{ url_for('auth.login') }}">{{ t("login_with_discord") }}</a>
   </div>
 {% endblock %}

--- a/tests/test_reminder_api.py
+++ b/tests/test_reminder_api.py
@@ -7,7 +7,7 @@ from bson import ObjectId
 
 def login_r4(client):
     with client.session_transaction() as sess:
-        sess["user"] = {"role_level": "ADMIN"}
+        sess["discord_user"] = {"role_level": "ADMIN"}
         sess["discord_roles"] = ["ADMIN"]
 
 
@@ -37,7 +37,7 @@ def test_deactivate_valid(client, monkeypatch):
     with client.application.test_request_context("/"):
         import flask
 
-        flask.session["user"] = {"role_level": "ADMIN"}
+        flask.session["discord_user"] = {"role_level": "ADMIN"}
         flask.session["discord_roles"] = ["ADMIN"]
         resp = mod.deactivate_reminder(reminder_id)
     assert resp.is_json
@@ -54,7 +54,7 @@ def test_deactivate_invalid_id(client, monkeypatch):
     with client.application.test_request_context("/"):
         import flask
 
-        flask.session["user"] = {"role_level": "ADMIN"}
+        flask.session["discord_user"] = {"role_level": "ADMIN"}
         flask.session["discord_roles"] = ["ADMIN"]
         resp = mod.deactivate_reminder("foo")
 

--- a/utils/discord_util.py
+++ b/utils/discord_util.py
@@ -68,7 +68,7 @@ def require_roles(roles):
         def wrapped(*args, **kwargs):
             user_roles = session.get("discord_roles", [])
             if not any(role in user_roles for role in roles):
-                return redirect(url_for("public.login"))
+                return redirect(url_for("auth.login"))
             return f(*args, **kwargs)
 
         return wrapped

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -17,6 +17,7 @@ from fur_lang.i18n import (
     is_rtl,
     t,
 )
+from web.auth_routes import auth_bp
 from web.champion_routes import champion_blueprint
 from web.poster_routes import poster_blueprint
 from web.reminder_routes import reminder_blueprint
@@ -154,6 +155,7 @@ def create_app() -> Flask:
     except Exception:
         app.logger.exception("❌ Blueprint registration failed")
 
+    app.register_blueprint(auth_bp)
     app.register_blueprint(champion_blueprint)
     app.register_blueprint(reminder_blueprint)
     app.register_blueprint(poster_blueprint)

--- a/web/auth/decorators.py
+++ b/web/auth/decorators.py
@@ -17,9 +17,9 @@ def login_required(view_func):
 
     @wraps(view_func)
     def wrapper(*args, **kwargs):
-        if "user" not in session:
+        if "discord_user" not in session:
             flash(t("login_required", default="Login required."), "warning")
-            return redirect(url_for("public.login"))
+            return redirect(url_for("auth.login"))
         return view_func(*args, **kwargs)
 
     return wrapper
@@ -30,9 +30,9 @@ def r3_required(view_func):
 
     @wraps(view_func)
     def wrapper(*args, **kwargs):
-        if session.get("user", {}).get("role_level") not in ["R3", "R4", "ADMIN"]:
+        if session.get("discord_user", {}).get("role_level") not in ["R3", "R4", "ADMIN"]:
             flash(t("member_only", default="Members only."))
-            return redirect(url_for("public.login"))
+            return redirect(url_for("auth.login"))
         return view_func(*args, **kwargs)
 
     return wrapper
@@ -43,9 +43,9 @@ def r4_required(view_func):
 
     @wraps(view_func)
     def wrapper(*args, **kwargs):
-        if session.get("user", {}).get("role_level") not in ["R4", "ADMIN"]:
+        if session.get("discord_user", {}).get("role_level") not in ["R4", "ADMIN"]:
             flash(t("admin_only", default="Admins only."))
-            return redirect(url_for("public.login"))
+            return redirect(url_for("auth.login"))
         return view_func(*args, **kwargs)
 
     return wrapper
@@ -56,9 +56,9 @@ def admin_required(view_func):
 
     @wraps(view_func)
     def wrapper(*args, **kwargs):
-        if session.get("user", {}).get("role_level") != "ADMIN":
+        if session.get("discord_user", {}).get("role_level") != "ADMIN":
             flash(t("superuser_only", default="Superuser only."))
-            return redirect(url_for("public.login"))
+            return redirect(url_for("auth.login"))
         return view_func(*args, **kwargs)
 
     return wrapper

--- a/web/auth_routes.py
+++ b/web/auth_routes.py
@@ -1,0 +1,143 @@
+import secrets
+from urllib.parse import urlencode
+
+import requests
+from flask import (
+    Blueprint,
+    current_app,
+    flash,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
+
+from fur_lang.i18n import t
+from mongo_service import get_collection
+
+auth_bp = Blueprint("auth", __name__)
+
+
+@auth_bp.route("/login")
+def login():
+    user = session.get("discord_user")
+    if user:
+        role = user.get("role_level")
+        if role in ["ADMIN", "R4"]:
+            return redirect(url_for("admin.dashboard"))
+        if role == "R3":
+            return redirect(url_for("member.dashboard"))
+    client_id = current_app.config["DISCORD_CLIENT_ID"]
+    redirect_uri = current_app.config["DISCORD_REDIRECT_URI"]
+    state = secrets.token_urlsafe(16)
+    session["discord_oauth_state"] = state
+    params = {
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "response_type": "code",
+        "scope": "identify guilds guilds.members.read",
+        "state": state,
+    }
+    url = f"https://discord.com/oauth2/authorize?{urlencode(params)}"
+    return redirect(url)
+
+
+@auth_bp.route("/callback")
+def callback():
+    code = request.args.get("code")
+    state = request.args.get("state")
+    if not code:
+        return t("missing_code", default="Missing OAuth code."), 400
+    if not state or state != session.pop("discord_oauth_state", None):
+        return t("invalid_oauth_state", default="Invalid OAuth state."), 400
+    token_res = requests.post(
+        "https://discord.com/api/oauth2/token",
+        data={
+            "client_id": current_app.config["DISCORD_CLIENT_ID"],
+            "client_secret": current_app.config["DISCORD_CLIENT_SECRET"],
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": current_app.config["DISCORD_REDIRECT_URI"],
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        timeout=10,
+    )
+    if token_res.status_code != 200:
+        current_app.logger.error("OAuth Token Error %s: %s", token_res.status_code, token_res.text)
+        flash(t("discord_login_failed", default="Discord login failed"), "danger")
+        return redirect(url_for("auth.login"))
+    access_token = token_res.json().get("access_token")
+    user_res = requests.get(
+        "https://discord.com/api/users/@me",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    user_data = user_res.json()
+    guild_res = requests.get(
+        f"https://discord.com/api/users/@me/guilds/{current_app.config['DISCORD_GUILD_ID']}/member",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    if guild_res.status_code != 200:
+        return (
+            t(
+                "guild_membership_required",
+                default="Not a member of the FUR Discord server",
+            ),
+            403,
+        )
+    guild_member = guild_res.json()
+    user_roles = set(str(role) for role in guild_member.get("roles", []))
+    r3_roles = set(map(str, current_app.config.get("R3_ROLE_IDS", set())))
+    r4_roles = set(map(str, current_app.config.get("R4_ROLE_IDS", set())))
+    admin_roles = set(map(str, current_app.config.get("ADMIN_ROLE_IDS", set())))
+    if user_roles & admin_roles:
+        role_level = "ADMIN"
+    elif user_roles & r4_roles:
+        role_level = "R4"
+    elif user_roles & r3_roles:
+        role_level = "R3"
+    else:
+        current_app.logger.warning("❌ Invalid Discord role")
+        return t("invalid_role", default="Invalid role for access"), 403
+    session["discord_roles"] = [role_level]
+    session["discord_user"] = {
+        "id": user_data["id"],
+        "username": user_data["username"],
+        "avatar": user_data["avatar"],
+        "email": user_data.get("email"),
+        "role_level": role_level,
+    }
+    session.permanent = True
+    get_collection("users").update_one(
+        {"discord_id": user_data["id"]},
+        {
+            "$set": {
+                "username": user_data["username"],
+                "avatar": user_data["avatar"],
+                "email": user_data.get("email"),
+                "role_level": role_level,
+            }
+        },
+        upsert=True,
+    )
+    flash(t("discord_login_success", default="Successfully logged in with Discord"), "success")
+    if role_level in ["ADMIN", "R4"]:
+        return redirect(url_for("admin.dashboard"))
+    return redirect(url_for("member.dashboard"))
+
+
+@auth_bp.route("/logout")
+def logout():
+    session.clear()
+    flash(t("logout_success", default="Logged out successfully."), "info")
+    return redirect(url_for("auth.login"))
+
+
+@auth_bp.route("/dashboard")
+def dashboard():
+    return render_template("public/dashboard.html")
+
+
+@auth_bp.route("/admin")
+def admin():
+    return redirect(url_for("admin.dashboard"))


### PR DESCRIPTION
## Summary
- add dedicated `auth_bp` blueprint with Discord OAuth login, callback, logout, dashboard and admin routes
- move login/session handling to use `discord_user` key and adjust decorators/utilities
- register new auth blueprint and update public routes, templates and tests accordingly

## Testing
- `black --check .`
- `flake8`
- `pytest` *(fails: ModuleNotFoundError and other collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_688e9621ff2883249b7c668ba5777d28