### PR TITLE
Protect public dashboard with login requirement

### DIFF
--- a/blueprints/public.py
+++ b/blueprints/public.py
@@ -17,7 +17,7 @@ from flask import (
 
 from fur_lang.i18n import get_supported_languages, t
 from mongo_service import get_collection
-from web.auth.decorators import r3_required
+from web.auth.decorators import login_required, r3_required
 
 public = Blueprint("public", __name__)
 
@@ -242,5 +242,6 @@ def bank_war_top5():
 
 
 @public.route("/dashboard")
+@login_required
 def dashboard():
     return render_template("public/dashboard.html")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,6 +74,7 @@ def app():
     app = create_app()
 
     from flask import Blueprint
+    from web.auth.decorators import login_required
 
     public = Blueprint("public", __name__)
 
@@ -85,7 +86,12 @@ def app():
     def landing():
         return "home"
 
+    @public.route("/login")
+    def login():
+        return "login"
+
     @public.route("/dashboard")
+    @login_required
     def public_dashboard():
         return "dash"
 

--- a/tests/test_i18n_en.py
+++ b/tests/test_i18n_en.py
@@ -13,6 +13,7 @@ routes = [
 def test_no_german_words(client):
     with client.session_transaction() as sess:
         sess["lang"] = "en"
+        sess["user"] = {"id": "1", "role_level": "ADMIN"}
     for route in routes:
         resp = client.get(route)
         assert resp.status_code == 200

--- a/tests/test_public_dashboard_access.py
+++ b/tests/test_public_dashboard_access.py
@@ -1,0 +1,11 @@
+def test_dashboard_requires_login(client):
+    resp = client.get("/dashboard")
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/login")
+
+
+def test_dashboard_access_with_login(client):
+    with client.session_transaction() as sess:
+        sess["user"] = {"id": "1"}
+    resp = client.get("/dashboard")
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- require authentication for the public dashboard route
- add coverage for unauthenticated and authenticated dashboard access
- adjust existing tests for authenticated dashboards

## Testing
- `python -m black --check .`
- `flake8`
- `pytest` *(fails: ModuleNotFoundError and other errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688e964a50b083248bfe977cfba2b90b