### PR TITLE
docs: document Discord OAuth env vars and login flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,27 @@ DEBUG=true
 `PROMETHEUS_ENDPOINT` legt fest, wo Prometheus die Metriken abrufen kann.
 Weitere Details zu allen Variablen finden sich in [docs/env_vars.md](docs/env_vars.md).
 
+### Discord OAuth `.env` Variablen
+
+Für den Discord-Login müssen folgende Variablen in `.env` gesetzt werden:
+
+- `DISCORD_CLIENT_ID`
+- `DISCORD_CLIENT_SECRET`
+- `DISCORD_REDIRECT_URI`
+- `DISCORD_GUILD_ID`
+- `DISCORD_TOKEN`
+- `R3_ROLE_IDS`, `R4_ROLE_IDS`, `ADMIN_ROLE_IDS`
+
+### Login- und Callback-Flow
+
+1. Nutzer ruft `/login/discord` auf und wird zu Discord weitergeleitet.
+2. Discord fragt Berechtigungen für die Scopes `identify`, `guilds` und `guilds.members.read` an.
+3. Nach Zustimmung leitet Discord zur in `DISCORD_REDIRECT_URI` konfigurierten URL (z. B. `/callback`) zurück und übergibt `code` und `state`.
+4. Die Anwendung validiert `state` und tauscht `code` mithilfe von `DISCORD_CLIENT_ID` und `DISCORD_CLIENT_SECRET` gegen ein Access Token.
+5. Mit diesem Token werden `/users/@me` sowie `/users/@me/guilds/{DISCORD_GUILD_ID}/member` abgefragt.
+6. Die Discord-Rollen werden mit `R3_ROLE_IDS`, `R4_ROLE_IDS` und `ADMIN_ROLE_IDS` verglichen; nur passende Rollen erhalten Zugriff.
+7. Abhängig vom Rollenlevel erfolgt die Weiterleitung zum Admin- oder Member-Dashboard.
+
 📡 Features
 
 ✅ Zwei-Wege-Kalendersync (Google ↔ MongoDB)


### PR DESCRIPTION
## Summary
- document required Discord OAuth `.env` variables
- describe login/callback flow and role checks for Discord authentication

## Testing
- no tests run (documentation change)

------
https://chatgpt.com/codex/tasks/task_e_688e9655a0b48324939f5c95a7f6a93c