### PR TITLE
Refactor auth decorators to consolidate checks

### DIFF
--- a/web/auth/decorators.py
+++ b/web/auth/decorators.py
@@ -24,11 +24,11 @@ def login_required(view_func):
 
     @wraps(view_func)
     def wrapper(*args, **kwargs):
-        if not _agent().is_logged_in():
-        if "discord_user" not in session:
+        if not _agent().is_logged_in() or "discord_user" not in session:
             flash(t("login_required", default="Login required."), "warning")
             return redirect(url_for("auth.login"))
-        return view_func(*args, **kwargs)
+        else:
+            return view_func(*args, **kwargs)
 
     return wrapper
 
@@ -38,12 +38,15 @@ def r3_required(view_func):
 
     @wraps(view_func)
     def wrapper(*args, **kwargs):
-        if not _agent().is_r3():
-        if session.get("discord_user", {}).get("role_level") not in ["R3", "R4", "ADMIN"]:
-
+        if not _agent().is_r3() or session.get("discord_user", {}).get("role_level") not in [
+            "R3",
+            "R4",
+            "ADMIN",
+        ]:
             flash(t("member_only", default="Members only."))
             return redirect(url_for("auth.login"))
-        return view_func(*args, **kwargs)
+        else:
+            return view_func(*args, **kwargs)
 
     return wrapper
 
@@ -53,11 +56,14 @@ def r4_required(view_func):
 
     @wraps(view_func)
     def wrapper(*args, **kwargs):
-        if not _agent().is_r4():
-        if session.get("discord_user", {}).get("role_level") not in ["R4", "ADMIN"]:
+        if not _agent().is_r4() or session.get("discord_user", {}).get("role_level") not in [
+            "R4",
+            "ADMIN",
+        ]:
             flash(t("admin_only", default="Admins only."))
             return redirect(url_for("auth.login"))
-        return view_func(*args, **kwargs)
+        else:
+            return view_func(*args, **kwargs)
 
     return wrapper
 
@@ -67,10 +73,10 @@ def admin_required(view_func):
 
     @wraps(view_func)
     def wrapper(*args, **kwargs):
-        if not _agent().is_admin():
-        if session.get("discord_user", {}).get("role_level") != "ADMIN":
+        if not _agent().is_admin() or session.get("discord_user", {}).get("role_level") != "ADMIN":
             flash(t("superuser_only", default="Superuser only."))
             return redirect(url_for("auth.login"))
-        return view_func(*args, **kwargs)
+        else:
+            return view_func(*args, **kwargs)
 
     return wrapper


### PR DESCRIPTION
## Summary
- consolidate authorization checks in login-required decorators
- ensure views run only when authorization succeeds

## Testing
- `python -m py_compile web/auth/decorators.py`
- `python - <<'PY'
import importlib.util
spec = importlib.util.spec_from_file_location('decorators', 'web/auth/decorators.py')
module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(module)
print('module imported')
PY`
- `black --check .`
- `flake8` *(fails: F821 undefined name 'secrets', etc.)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_688ed067f1448324a7108302f4b9255c