### PR TITLE
Add detect-secrets scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      - name: 🔐 Secret Scan – detect-secrets
+        run: |
+          pip install detect-secrets
+          detect-secrets-hook --baseline .secrets.baseline
+
       - name: 🧹 Code Style – Black
         run: black . --check
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,8 @@ repos:
     rev: v7.4.3
     hooks:
       - id: pytest
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: ['--baseline', '.secrets.baseline']

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,274 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {
+    ".github/workflows/ci.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/ci.yml",
+        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
+        "is_verified": false,
+        "line_number": 26
+      }
+    ],
+    "attached_assets/Pasted--Google-Calendar-Integration-mit-MongoDB-OAuth2-optimiert-from-flask-import-Flask-session--1752426621120_1752426621130.txt": [
+      {
+        "type": "Secret Keyword",
+        "filename": "attached_assets/Pasted--Google-Calendar-Integration-mit-MongoDB-OAuth2-optimiert-from-flask-import-Flask-session--1752426621120_1752426621130.txt",
+        "hashed_secret": "0d4d67c9ad250fdb28cfb72a1105b8a78034097d",
+        "is_verified": false,
+        "line_number": 22
+      }
+    ],
+    "attached_assets/Pasted-REPO-GITHUB-Rabbit-Fur-try-FUR-PAT-github-pat-11BSDRQHY0pZgGyCS54Bbx-HqGQT7sKf10W2qrG3PcxcPI5IpizZa8-1752423344424_1752423344427.txt": [
+      {
+        "type": "GitHub Token",
+        "filename": "attached_assets/Pasted-REPO-GITHUB-Rabbit-Fur-try-FUR-PAT-github-pat-11BSDRQHY0pZgGyCS54Bbx-HqGQT7sKf10W2qrG3PcxcPI5IpizZa8-1752423344424_1752423344427.txt",
+        "hashed_secret": "e175c6f5f2a92e8623bd9a4820edb4e8c1b0fd10",
+        "is_verified": false,
+        "line_number": 3
+      },
+      {
+        "type": "Discord Bot Token",
+        "filename": "attached_assets/Pasted-REPO-GITHUB-Rabbit-Fur-try-FUR-PAT-github-pat-11BSDRQHY0pZgGyCS54Bbx-HqGQT7sKf10W2qrG3PcxcPI5IpizZa8-1752423344424_1752423344427.txt",
+        "hashed_secret": "5587e2f5b4fb1a0da49a45e33a7409b54cb712cd",
+        "is_verified": false,
+        "line_number": 4
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "attached_assets/Pasted-REPO-GITHUB-Rabbit-Fur-try-FUR-PAT-github-pat-11BSDRQHY0pZgGyCS54Bbx-HqGQT7sKf10W2qrG3PcxcPI5IpizZa8-1752423344424_1752423344427.txt",
+        "hashed_secret": "c459a2ce735db426cfb19bdbc38469c96feb1dbf",
+        "is_verified": false,
+        "line_number": 42
+      }
+    ],
+    "attached_assets/Pasted-REPO-GITHUB-Rabbit-Fur-try-FUR-PAT-github-pat-11BSDRQHY0pZgGyCS54Bbx-HqGQT7sKf10W2qrG3PcxcPI5IpizZa8-1752423344939_1752423344940.txt": [
+      {
+        "type": "GitHub Token",
+        "filename": "attached_assets/Pasted-REPO-GITHUB-Rabbit-Fur-try-FUR-PAT-github-pat-11BSDRQHY0pZgGyCS54Bbx-HqGQT7sKf10W2qrG3PcxcPI5IpizZa8-1752423344939_1752423344940.txt",
+        "hashed_secret": "e175c6f5f2a92e8623bd9a4820edb4e8c1b0fd10",
+        "is_verified": false,
+        "line_number": 3
+      },
+      {
+        "type": "Discord Bot Token",
+        "filename": "attached_assets/Pasted-REPO-GITHUB-Rabbit-Fur-try-FUR-PAT-github-pat-11BSDRQHY0pZgGyCS54Bbx-HqGQT7sKf10W2qrG3PcxcPI5IpizZa8-1752423344939_1752423344940.txt",
+        "hashed_secret": "5587e2f5b4fb1a0da49a45e33a7409b54cb712cd",
+        "is_verified": false,
+        "line_number": 4
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "attached_assets/Pasted-REPO-GITHUB-Rabbit-Fur-try-FUR-PAT-github-pat-11BSDRQHY0pZgGyCS54Bbx-HqGQT7sKf10W2qrG3PcxcPI5IpizZa8-1752423344939_1752423344940.txt",
+        "hashed_secret": "c459a2ce735db426cfb19bdbc38469c96feb1dbf",
+        "is_verified": false,
+        "line_number": 42
+      }
+    ],
+    "attached_assets/Pasted-REPO-GITHUB-Rabbit-Fur-try-FUR-PAT-github-pat-11BSDRQHY0pZgGyCS54Bbx-HqGQT7sKf10W2qrG3PcxcPI5IpizZa8-1752423361042_1752423361043.txt": [
+      {
+        "type": "GitHub Token",
+        "filename": "attached_assets/Pasted-REPO-GITHUB-Rabbit-Fur-try-FUR-PAT-github-pat-11BSDRQHY0pZgGyCS54Bbx-HqGQT7sKf10W2qrG3PcxcPI5IpizZa8-1752423361042_1752423361043.txt",
+        "hashed_secret": "e175c6f5f2a92e8623bd9a4820edb4e8c1b0fd10",
+        "is_verified": false,
+        "line_number": 3
+      },
+      {
+        "type": "Discord Bot Token",
+        "filename": "attached_assets/Pasted-REPO-GITHUB-Rabbit-Fur-try-FUR-PAT-github-pat-11BSDRQHY0pZgGyCS54Bbx-HqGQT7sKf10W2qrG3PcxcPI5IpizZa8-1752423361042_1752423361043.txt",
+        "hashed_secret": "5587e2f5b4fb1a0da49a45e33a7409b54cb712cd",
+        "is_verified": false,
+        "line_number": 4
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "attached_assets/Pasted-REPO-GITHUB-Rabbit-Fur-try-FUR-PAT-github-pat-11BSDRQHY0pZgGyCS54Bbx-HqGQT7sKf10W2qrG3PcxcPI5IpizZa8-1752423361042_1752423361043.txt",
+        "hashed_secret": "c459a2ce735db426cfb19bdbc38469c96feb1dbf",
+        "is_verified": false,
+        "line_number": 42
+      }
+    ],
+    "tests/auth/test_auth_agent_decorators.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/auth/test_auth_agent_decorators.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 38
+      }
+    ],
+    "tests/services/google/test_auth.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/services/google/test_auth.py",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 11
+      }
+    ],
+    "tests/services/google/test_oauth_setup.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/services/google/test_oauth_setup.py",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 21
+      }
+    ],
+    "tests/test_google_oauth_web.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_google_oauth_web.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 11
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_google_oauth_web.py",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 22
+      }
+    ],
+    "tests/test_oauth_utils.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/test_oauth_utils.py",
+        "hashed_secret": "0ed8ae366b89be609d7efce432ede277ac3094d3",
+        "is_verified": false,
+        "line_number": 26
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_oauth_utils.py",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 49
+      }
+    ]
+  },
+  "generated_at": "2025-08-10T04:04:51Z"
+}


### PR DESCRIPTION
## Summary
- integrate detect-secrets into pre-commit
- add baseline and CI step for secret scanning

## Testing
- `detect-secrets-hook --baseline .secrets.baseline`
- `black . --check` *(fails: would reformat tests/services/google/test_oauth_setup.py, web/auth/decorators.py, web/routes/google_oauth_web.py)*
- `flake8 .` *(fails: undefined names in blueprints/public.py, tests/services/google/test_oauth_setup.py, tests/test_public_flows.py, utils/oauth_utils.py, web/auth/decorators.py)*
- `pytest` *(fails: MongoDB connection refused and IndentationError in web/auth/decorators.py)*

------
https://chatgpt.com/codex/tasks/task_e_689819fbe1048324a7a21bf75016597e