### PR TITLE
docs: document DEFAULT_DM_IMAGE_URL in env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,7 @@ REMINDER_ROLE_ID=               # Rolle für Reminder-Mentions
 # === Reminder & Newsletter ===
 ENABLE_CHANNEL_REMINDERS=false   # Reminder in Channel posten
 REMINDER_DM_DELAY=1              # Sekunden zwischen DM-Remindern
+DEFAULT_DM_IMAGE_URL=https://fur-martix.up.railway.app/static/img/dm_default.png  # Fallback-Bild für DMs
 REMINDER_DM_IMAGE_URL=https://fur-martix.up.railway.app/static/img/dm_default.png  # Bild für Reminder-DMs
 ENABLE_NEWSLETTER_AUTOPILOT=true # Wöchentlicher Newsletter
 NEWSLETTER_DM_DELAY=1            # Sekunden zwischen Newsletter-DMs


### PR DESCRIPTION
## Summary
- document `DEFAULT_DM_IMAGE_URL` in `.env.example` so default DM images can be configured

## Testing
- `black --check .` *(fails: would reformat tests/services/google/test_oauth_setup.py, web/routes/google_oauth_web.py and parse error in web/auth/decorators.py)*
- `flake8` *(fails: undefined names in blueprints/public.py, web/auth/decorators.py and others)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask_babel')*

------
https://chatgpt.com/codex/tasks/task_e_689819f959e0832495f80fde1b57c96f