### PR TITLE
docs: document CalendarService APScheduler sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,36 @@ Codex blockiert Deployment ohne .env.example + Commit-Lint
 - Vollständig modular, robust und testbar umgesetzt
 - Für Setup siehe `requirements.txt` und API-Doku im Ordner `docs/`
 
+### APScheduler Calendar Sync Example
+
+Schedule periodic synchronisation by creating a `CalendarService` within a
+Flask application context. The job interval is driven by the
+``GOOGLE_SYNC_INTERVAL_MINUTES`` configuration (default ``30`` minutes). OAuth
+tokens are loaded from the path specified via ``GOOGLE_TOKEN_STORAGE_PATH`` or
+``GOOGLE_CREDENTIALS_FILE``.
+
+```python
+from apscheduler.schedulers.background import BackgroundScheduler
+import asyncio, os
+from services import CalendarService
+from web import create_app
+
+app = create_app()
+scheduler = BackgroundScheduler()
+
+def sync_calendar():
+    with app.app_context():
+        service = CalendarService()
+        asyncio.run(service.sync())
+
+scheduler.add_job(
+    sync_calendar,
+    "interval",
+    minutes=int(os.getenv("GOOGLE_SYNC_INTERVAL_MINUTES", "30")),
+)
+scheduler.start()
+```
+
 📬 Kontakt
 
 Maintainer: Marcel Schlanzke

--- a/services/google/sync_task.py
+++ b/services/google/sync_task.py
@@ -1,4 +1,32 @@
-"""Background task to sync Google Calendar periodically."""
+"""Background task to sync Google Calendar periodically.
+
+Example APScheduler setup::
+
+    import asyncio
+    import os
+    from apscheduler.schedulers.background import BackgroundScheduler
+    from services import CalendarService
+    from web import create_app
+
+    app = create_app()
+    scheduler = BackgroundScheduler()
+
+    def sync_google():
+        with app.app_context():
+            service = CalendarService()
+            asyncio.run(service.sync())
+
+    scheduler.add_job(
+        sync_google,
+        "interval",
+        minutes=int(os.getenv("GOOGLE_SYNC_INTERVAL_MINUTES", "30")),
+    )
+    scheduler.start()
+
+``GOOGLE_SYNC_INTERVAL_MINUTES`` controls the sync frequency in minutes.
+OAuth tokens are loaded from ``GOOGLE_TOKEN_STORAGE_PATH`` or
+``GOOGLE_CREDENTIALS_FILE``.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- document APScheduler job example that instantiates `CalendarService` inside `app.app_context`
- describe `GOOGLE_SYNC_INTERVAL_MINUTES`-driven sync interval and token path env vars

## Testing
- `black --check .` *(fails: would reformat tests/services/google/test_oauth_setup.py, web/auth/decorators.py)*
- `flake8` *(fails: undefined names and other errors in unrelated files)*
- `pytest` *(fails: IndentationError in web/auth/decorators.py)*

------
https://chatgpt.com/codex/tasks/task_e_68981df3001483249cbe124d13eea617