### PR TITLE
feat: add session role helpers

### DIFF
--- a/blueprints/public.py
+++ b/blueprints/public.py
@@ -1,3 +1,7 @@
+import secrets
+from urllib.parse import urlencode
+
+import requests
 from bson import ObjectId
 from flask import (
     Blueprint,
@@ -170,6 +174,7 @@ def discord_callback():
         "avatar": user_data["avatar"],
         "email": user_data.get("email"),
         "role_level": role_level,
+        "roles": list(user_roles),
     }
     session.permanent = True
 

--- a/tests/services/google/test_oauth_setup.py
+++ b/tests/services/google/test_oauth_setup.py
@@ -50,4 +50,3 @@ def test_main_requires_client_credentials(tmp_path, monkeypatch):
 
     with pytest.raises(KeyError):
         mod.main()
-

--- a/tests/test_public_flows.py
+++ b/tests/test_public_flows.py
@@ -7,6 +7,7 @@ import requests
 import mongo_service
 
 auth_mod = importlib.import_module("web.auth_routes")
+public_mod = importlib.import_module("blueprints.public")
 
 
 def get_flashes(client):

--- a/utils/oauth_utils.py
+++ b/utils/oauth_utils.py
@@ -76,7 +76,6 @@ def exchange_code_for_token(
     client_id: str,
     client_secret: str,
     redirect_uri: str,
-    client_secret: str,
 ) -> dict:
     """Exchange authorization ``code`` for OAuth tokens."""
     data = {

--- a/web/auth/decorators.py
+++ b/web/auth/decorators.py
@@ -1,13 +1,15 @@
 """
-web/auth/decorators.py – Rollen- & Login-Decorator für Flask
+Role and login decorators for Flask views.
 
-Dekoratoren für Flask-Views: login_required, r3_required, r4_required.
-Stellen sicher, dass der User korrekt eingeloggt ist und die passende Rolle (R3, R4, Admin) hat.
+This module provides helpers to ensure a user is logged in and has the
+necessary Discord roles stored in the session. Role checks operate on role IDs
+so that a user can belong to multiple groups (R3/R4/Admin) simultaneously.
 """
 
+from collections.abc import Iterable
 from functools import wraps
 
-from flask import flash, redirect, session, url_for
+from flask import current_app, flash, redirect, session, url_for
 
 import mongo_service
 from agents.auth_agent import AuthAgent
@@ -15,72 +17,103 @@ from agents.auth_agent import AuthAgent
 from fur_lang.i18n import t
 
 
-def _agent():
+def _agent() -> AuthAgent:
+    """Return an ``AuthAgent`` bound to the current session."""
+
     return AuthAgent(session, mongo_service.db)
 
 
+def _session_roles() -> list[str]:
+    """Return the current user's Discord role IDs as strings.
+
+    ``session['discord_user']['roles']`` may contain integers or strings; this
+    helper normalises them into a list of strings. Missing keys result in an
+    empty list.
+    """
+
+    return [str(role) for role in session.get("discord_user", {}).get("roles", [])]
+
+
+def _as_list(value) -> list[str]:
+    """Normalize a config value into a list of strings.
+
+    Accepts comma separated strings or any iterable of IDs. ``None`` yields an
+    empty list.
+    """
+
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [v.strip() for v in value.split(",") if v.strip()]
+    if isinstance(value, Iterable):
+        return [str(v) for v in value]
+    return [str(value)]
+
+
+def _has_any_required_role(required_ids) -> bool:
+    """Check if the session user has at least one of ``required_ids``."""
+
+    session_roles = set(_session_roles())
+    required = set(_as_list(required_ids))
+    return bool(session_roles & required)
+
+
 def login_required(view_func):
-    """Schützt eine Route für eingeloggte User."""
+    """Protect a route for logged in users."""
 
     @wraps(view_func)
     def wrapper(*args, **kwargs):
-        if not _agent().is_logged_in():
         if not _agent().is_logged_in() or "discord_user" not in session:
             flash(t("login_required", default="Login required."), "warning")
             return redirect(url_for("auth.login"))
-        else:
-            return view_func(*args, **kwargs)
+        return view_func(*args, **kwargs)
 
     return wrapper
 
 
 def r3_required(view_func):
-    """Zugriff nur für Mitglieder (R3+, Admin)."""
+    """Allow access only for members (R3+, Admin)."""
 
     @wraps(view_func)
     def wrapper(*args, **kwargs):
-        if not _agent().is_r3():
-        if not _agent().is_r3() or session.get("discord_user", {}).get("role_level") not in [
-            "R3",
-            "R4",
-            "ADMIN",
-        ]:
+        required = (
+            _as_list(current_app.config.get("R3_ROLE_IDS"))
+            + _as_list(current_app.config.get("R4_ROLE_IDS"))
+            + _as_list(current_app.config.get("ADMIN_ROLE_IDS"))
+        )
+        if not _has_any_required_role(required):
             flash(t("member_only", default="Members only."))
             return redirect(url_for("auth.login"))
-        else:
-            return view_func(*args, **kwargs)
+        return view_func(*args, **kwargs)
 
     return wrapper
 
 
 def r4_required(view_func):
-    """Zugriff nur für R4 oder Admin."""
+    """Allow access only for R4 or Admin roles."""
 
     @wraps(view_func)
     def wrapper(*args, **kwargs):
-        if not _agent().is_r4():
-        if not _agent().is_r4() or session.get("discord_user", {}).get("role_level") not in [
-            "R4",
-            "ADMIN",
-        ]:
+        required = _as_list(current_app.config.get("R4_ROLE_IDS")) + _as_list(
+            current_app.config.get("ADMIN_ROLE_IDS")
+        )
+        if not _has_any_required_role(required):
             flash(t("admin_only", default="Admins only."))
             return redirect(url_for("auth.login"))
-        else:
-            return view_func(*args, **kwargs)
+        return view_func(*args, **kwargs)
 
     return wrapper
 
 
 def admin_required(view_func):
-    """Zugriff nur für System-Admins."""
+    """Allow access only for system administrators."""
 
     @wraps(view_func)
     def wrapper(*args, **kwargs):
-        if not _agent().is_admin():
-        if not _agent().is_admin() or session.get("discord_user", {}).get("role_level") != "ADMIN":
+        required = _as_list(current_app.config.get("ADMIN_ROLE_IDS"))
+        if not _has_any_required_role(required):
             flash(t("superuser_only", default="Superuser only."))
             return redirect(url_for("auth.login"))
-        else:
-            return view_func(*args, **kwargs)
+        return view_func(*args, **kwargs)
 
     return wrapper

--- a/web/auth_routes.py
+++ b/web/auth_routes.py
@@ -106,6 +106,7 @@ def callback():
         "avatar": user_data["avatar"],
         "email": user_data.get("email"),
         "role_level": role_level,
+        "roles": list(user_roles),
     }
     session.permanent = True
     get_collection("users").update_one(

--- a/web/routes/google_oauth_web.py
+++ b/web/routes/google_oauth_web.py
@@ -15,19 +15,13 @@ oauth_bp = Blueprint("oauth_web", __name__)
 
 # Constants
 SCOPES = ["https://www.googleapis.com/auth/calendar"]
-REDIRECT_URI = os.getenv(
-    "GOOGLE_REDIRECT_URI", "https://fur-martix.up.railway.app/oauth2callback"
-)
+REDIRECT_URI = os.getenv("GOOGLE_REDIRECT_URI", "https://fur-martix.up.railway.app/oauth2callback")
 CLIENT_CONFIG = {
     "web": {
         "client_id": os.getenv("GOOGLE_CLIENT_ID"),
         "project_id": os.getenv("GOOGLE_PROJECT_ID"),
-        "auth_uri": os.getenv(
-            "GOOGLE_AUTH_URI", "https://accounts.google.com/o/oauth2/auth"
-        ),
-        "token_uri": os.getenv(
-            "GOOGLE_TOKEN_URI", "https://oauth2.googleapis.com/token"
-        ),
+        "auth_uri": os.getenv("GOOGLE_AUTH_URI", "https://accounts.google.com/o/oauth2/auth"),
+        "token_uri": os.getenv("GOOGLE_TOKEN_URI", "https://oauth2.googleapis.com/token"),
         "auth_provider_x509_cert_url": os.getenv(
             "GOOGLE_AUTH_PROVIDER_CERT_URL", "https://www.googleapis.com/v1/certs"
         ),


### PR DESCRIPTION
## Summary
- add utilities for parsing session roles and role ID config values
- enforce role requirements via role ID intersection
- persist raw Discord role IDs in session after login

## Testing
- `black --check .`
- `flake8`
- `pytest` *(fails: TypeError: PyObjectId.validate() takes 2 positional arguments ...)*

------
https://chatgpt.com/codex/tasks/task_e_68981dc40d5c832494409369af706317