### PR TITLE
Refactor Google calendar configuration usage

### DIFF
--- a/services/calendar_service.py
+++ b/services/calendar_service.py
@@ -4,8 +4,7 @@ import os
 from datetime import date as date_type, datetime, timedelta, timezone
 from typing import Any, Iterable, Optional
 
-from flask import current_app
-from web import create_app
+from flask import current_app, has_app_context
 
 from discord.ext import tasks
 from googleapiclient.discovery import build
@@ -13,27 +12,12 @@ from googleapiclient.errors import HttpError
 from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorCollection
 from pymongo.errors import ConfigurationError
 
-from config import Config
 from crud import event_crud
 from services.google.auth import load_credentials
 from schemas.event_schema import EventModel
 from utils.time_utils import parse_calendar_datetime
 
 log = logging.getLogger(__name__)
-
-
-_app = None
-
-
-def _get_app():
-    """Return a Flask application instance."""
-    global _app
-    try:
-        return current_app._get_current_object()
-    except RuntimeError:
-        if _app is None:
-            _app = create_app()
-        return _app
 
 
 class SyncTokenExpired(Exception):
@@ -51,10 +35,19 @@ class CalendarService:
         events_collection: Optional[AsyncIOMotorCollection] = None,
         tokens_collection: Optional[AsyncIOMotorCollection] = None,
     ) -> None:
-        self.calendar_id = calendar_id or Config.GOOGLE_CALENDAR_ID
+        if calendar_id is None:
+            if has_app_context():
+                calendar_id = current_app.config.get("GOOGLE_CALENDAR_ID")
+            else:
+                calendar_id = os.getenv("GOOGLE_CALENDAR_ID")
+        self.calendar_id = calendar_id
         self.service: Any | None = None
-        self.warned_missing_creds = False
-        uri = mongo_uri or Config.MONGODB_URI or "mongodb://localhost:27017/furdb"
+        uri = mongo_uri
+        if uri is None:
+            if has_app_context():
+                uri = current_app.config.get("MONGODB_URI")
+            if not uri:
+                uri = os.getenv("MONGODB_URI", "mongodb://localhost:27017/furdb")
         if events_collection is not None and tokens_collection is not None:
             self.client = None
             self.events = events_collection
@@ -75,16 +68,9 @@ class CalendarService:
     def _build_service(self) -> None:
         if self.service:
             return
-        app = _get_app()
-        with app.app_context():
-            creds = load_credentials()
+        creds = load_credentials()
         if not creds:
-            if not self.warned_missing_creds:
-                log.warning("Google credentials missing – cannot sync")
-                self.warned_missing_creds = True
-            self.service = None
-            return
-        self.warned_missing_creds = False
+            raise SyncTokenExpired("Google credentials missing or invalid")
         self.service = build(
             "calendar",
             "v3",
@@ -94,9 +80,6 @@ class CalendarService:
 
     async def _api_list(self, params: dict) -> dict:
         self._build_service()
-        if not self.service:
-            log.warning("Calendar service not initialized – skipping")
-            return {}
         return await asyncio.to_thread(self.service.events().list(**params).execute)
 
     # ------------------------------------------------------------------

--- a/services/google/calendar_sync.py
+++ b/services/google/calendar_sync.py
@@ -5,13 +5,18 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Optional
 
+from flask import current_app, has_app_context
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
 
-from config import Config
 from mongo_service import get_collection
 from utils.time_utils import parse_calendar_datetime
+
+
+class SyncTokenExpired(Exception):
+    """Raised when the Google OAuth token is missing or invalid."""
+
 
 # Logging setup
 LOG_PATH = Path("logs")
@@ -36,8 +41,18 @@ def init_logging() -> None:
 
 init_logging()
 
-# Token path
-TOKEN_PATH = Path(os.getenv("GOOGLE_CREDENTIALS_FILE", "/data/google_token.json"))
+
+def _token_path() -> Path:
+    """Return the configured OAuth token storage path."""
+    if has_app_context():
+        cfg = current_app.config
+        path = cfg.get("GOOGLE_TOKEN_STORAGE_PATH") or cfg.get("GOOGLE_CREDENTIALS_FILE")
+        if path:
+            return Path(path)
+    env_path = os.environ.get("GOOGLE_TOKEN_STORAGE_PATH") or os.environ.get(
+        "GOOGLE_CREDENTIALS_FILE"
+    )
+    return Path(env_path or "/data/google_token.json")
 
 
 def _get_token_collection():
@@ -84,13 +99,14 @@ _warned_once = False
 def load_credentials() -> Optional[Credentials]:
     """Load stored credentials from JSON and refresh if needed."""
     global _warned_once
-    if not TOKEN_PATH.exists():
+    path = _token_path()
+    if not path.exists():
         if not _warned_once:
-            logger.warning("No Google credentials found at %s", TOKEN_PATH)
+            logger.warning("No Google credentials found at %s", path)
             _warned_once = True
         return None
     try:
-        info = json.loads(TOKEN_PATH.read_text())
+        info = json.loads(path.read_text())
     except Exception:  # noqa: BLE001
         logger.exception("Failed to read credentials JSON")
         return None
@@ -101,21 +117,32 @@ def load_credentials() -> Optional[Credentials]:
         if ("installed" in info or "web" in info) and not _warned_once:
             logger.warning(
                 "Credentials file %s looks like an OAuth client config, not a saved token",
-                TOKEN_PATH,
+                path,
             )
             _warned_once = True
         elif not _warned_once:
             missing = ", ".join(sorted(required - keys))
-            logger.warning("Credentials file %s missing required keys: %s", TOKEN_PATH, missing)
+            logger.warning("Credentials file %s missing required keys: %s", path, missing)
             _warned_once = True
         return None
 
     try:
-        creds = Credentials.from_authorized_user_file(TOKEN_PATH, Config.GOOGLE_CALENDAR_SCOPES)
+        scopes = (
+            current_app.config.get(
+                "GOOGLE_CALENDAR_SCOPES",
+                ["https://www.googleapis.com/auth/calendar.readonly"],
+            )
+            if has_app_context()
+            else os.environ.get(
+                "GOOGLE_CALENDAR_SCOPES",
+                "https://www.googleapis.com/auth/calendar.readonly",
+            ).split(",")
+        )
+        creds = Credentials.from_authorized_user_info(info, scopes)
         if creds.expired and creds.refresh_token:
             logger.info("Refreshing Google credentials")
             creds.refresh(Request())
-            TOKEN_PATH.write_text(creds.to_json())
+            path.write_text(creds.to_json())
         _warned_once = False
         return creds
     except Exception:  # noqa: BLE001
@@ -123,16 +150,23 @@ def load_credentials() -> Optional[Credentials]:
         return None
 
 
+_SERVICE: Any | None = None
+
+
 def get_calendar_service():
-    """Return Google Calendar API service or ``None`` if credentials missing."""
+    """Return a cached Google Calendar API service."""
+    global _SERVICE
+    if _SERVICE:
+        return _SERVICE
     creds = load_credentials()
     if not creds:
-        return None
+        raise SyncTokenExpired("Missing Google OAuth token")
     try:
-        return build("calendar", "v3", credentials=creds, cache_discovery=False)
+        _SERVICE = build("calendar", "v3", credentials=creds, cache_discovery=False)
+        return _SERVICE
     except Exception:  # noqa: BLE001
         logger.exception("Failed to build Google Calendar service")
-        return None
+        raise
 
 
 def fetch_upcoming_events(
@@ -145,12 +179,13 @@ def fetch_upcoming_events(
 ) -> list[dict]:
     """Fetch events from Google Calendar."""
     service = service or get_calendar_service()
-    if not service:
-        return []
-    calendar_id = calendar_id or Config.GOOGLE_CALENDAR_ID
-    if not calendar_id:
-        logger.warning("GOOGLE_CALENDAR_ID not configured")
-        return []
+    calendar_id = calendar_id
+    if calendar_id is None:
+        if has_app_context():
+            calendar_id = current_app.config.get("GOOGLE_CALENDAR_ID")
+        if not calendar_id:
+            logger.warning("GOOGLE_CALENDAR_ID not configured")
+            return []
 
     params = {
         "calendarId": calendar_id,
@@ -177,6 +212,12 @@ def fetch_upcoming_events(
     except Exception:  # noqa: BLE001
         logger.exception("Failed to fetch events from Google Calendar")
     return events
+
+
+def list_upcoming_events(max_results: int = 10) -> list[dict]:
+    """Return upcoming Google Calendar events."""
+    now = datetime.utcnow().astimezone(timezone.utc)
+    return fetch_upcoming_events(time_min=now, max_results=max_results)
 
 
 def _build_doc(event: dict) -> dict:
@@ -211,10 +252,10 @@ def _build_doc(event: dict) -> dict:
 def sync_to_mongodb(collection: str = "calendar_events") -> int:
     """Fetch events and upsert them into MongoDB."""
     service = get_calendar_service()
-    if not service:
-        logger.warning("No calendar service – skipping sync")
-        return 0
-    calendar_id = Config.GOOGLE_CALENDAR_ID or "primary"
+    if has_app_context():
+        calendar_id = current_app.config.get("GOOGLE_CALENDAR_ID", "primary")
+    else:
+        calendar_id = os.environ.get("GOOGLE_CALENDAR_ID", "primary")
     events = fetch_upcoming_events(service=service, calendar_id=calendar_id)
     if not events:
         logger.info("No events returned from calendar")
@@ -257,3 +298,14 @@ def create_test_event(
     except Exception:
         logger.exception("Failed to create test event")
         return None
+
+
+__all__ = [
+    "SyncTokenExpired",
+    "load_credentials",
+    "get_calendar_service",
+    "fetch_upcoming_events",
+    "list_upcoming_events",
+    "sync_to_mongodb",
+    "create_test_event",
+]

--- a/web/auth/decorators.py
+++ b/web/auth/decorators.py
@@ -24,12 +24,10 @@ def login_required(view_func):
 
     @wraps(view_func)
     def wrapper(*args, **kwargs):
-        if not _agent().is_logged_in():
         if not _agent().is_logged_in() or "discord_user" not in session:
             flash(t("login_required", default="Login required."), "warning")
             return redirect(url_for("auth.login"))
-        else:
-            return view_func(*args, **kwargs)
+        return view_func(*args, **kwargs)
 
     return wrapper
 
@@ -39,7 +37,6 @@ def r3_required(view_func):
 
     @wraps(view_func)
     def wrapper(*args, **kwargs):
-        if not _agent().is_r3():
         if not _agent().is_r3() or session.get("discord_user", {}).get("role_level") not in [
             "R3",
             "R4",
@@ -47,8 +44,7 @@ def r3_required(view_func):
         ]:
             flash(t("member_only", default="Members only."))
             return redirect(url_for("auth.login"))
-        else:
-            return view_func(*args, **kwargs)
+        return view_func(*args, **kwargs)
 
     return wrapper
 
@@ -58,15 +54,13 @@ def r4_required(view_func):
 
     @wraps(view_func)
     def wrapper(*args, **kwargs):
-        if not _agent().is_r4():
         if not _agent().is_r4() or session.get("discord_user", {}).get("role_level") not in [
             "R4",
             "ADMIN",
         ]:
             flash(t("admin_only", default="Admins only."))
             return redirect(url_for("auth.login"))
-        else:
-            return view_func(*args, **kwargs)
+        return view_func(*args, **kwargs)
 
     return wrapper
 
@@ -76,11 +70,9 @@ def admin_required(view_func):
 
     @wraps(view_func)
     def wrapper(*args, **kwargs):
-        if not _agent().is_admin():
         if not _agent().is_admin() or session.get("discord_user", {}).get("role_level") != "ADMIN":
             flash(t("superuser_only", default="Superuser only."))
             return redirect(url_for("auth.login"))
-        else:
-            return view_func(*args, **kwargs)
+        return view_func(*args, **kwargs)
 
     return wrapper


### PR DESCRIPTION
## Summary
- build Google Calendar client lazily and raise `SyncTokenExpired` if credentials are missing
- drive calendar settings from `current_app.config` and expose `list_upcoming_events`
- start sync task within app context using configurable interval

## Testing
- `black --check services/google/sync_task.py services/calendar_service.py services/google/calendar_sync.py tests/services/google/test_sync.py tests/services/google/test_calendar_sync.py web/auth/decorators.py`
- `flake8 services/google/sync_task.py services/calendar_service.py services/google/calendar_sync.py tests/services/google/test_sync.py tests/services/google/test_calendar_sync.py web/auth/decorators.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'prometheus_client')*

------
https://chatgpt.com/codex/tasks/task_e_68981db364a4832497ab131424cfe062