### PR TITLE
Raise SyncTokenExpired on missing Google token

### DIFF
--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,4 +1,5 @@
-from .calendar_service import CalendarService, DMReminderScheduler, SyncTokenExpired
+from .calendar_service import CalendarService, DMReminderScheduler
+from .google.exceptions import SyncTokenExpired
 from .langchain_service import LangchainService
 from .github_sync import GitHubSyncService
 

--- a/services/google/exceptions.py
+++ b/services/google/exceptions.py
@@ -1,0 +1,2 @@
+class SyncTokenExpired(Exception):
+    """Raised when stored OAuth token is missing or invalid."""

--- a/tests/services/google/test_auth.py
+++ b/tests/services/google/test_auth.py
@@ -2,7 +2,9 @@ import json
 import logging
 import os
 
+import pytest
 import services.google.auth as mod
+from services.google.exceptions import SyncTokenExpired
 
 
 def test_google_login_flow(client, monkeypatch):
@@ -79,7 +81,8 @@ def test_load_credentials_invalid_returns_none(tmp_path, app, caplog):
     app.config.update(GOOGLE_CALENDAR_SCOPES=["scope"])
 
     with caplog.at_level(logging.ERROR):
-        assert mod.load_credentials() is None
+        with pytest.raises(SyncTokenExpired):
+            mod.load_credentials()
     assert "Invalid credentials" in caplog.text
 
 
@@ -90,7 +93,8 @@ def test_load_credentials_missing_file(tmp_path, app, caplog):
     app.config.update(GOOGLE_CALENDAR_SCOPES=["scope"])
 
     with caplog.at_level(logging.WARNING):
-        assert mod.load_credentials() is None
+        with pytest.raises(SyncTokenExpired):
+            mod.load_credentials()
     assert "Token file not found" in caplog.text
 
 

--- a/tests/services/google/test_sync.py
+++ b/tests/services/google/test_sync.py
@@ -1,7 +1,9 @@
 from datetime import timezone
 
 import logging
+import pytest
 import services.google.calendar_sync as mod
+from services.google.exceptions import SyncTokenExpired
 
 
 class DummyCollection:
@@ -67,11 +69,13 @@ def test_load_credentials_warns_once(monkeypatch, tmp_path, caplog):
     monkeypatch.setattr(mod, "TOKEN_PATH", missing, raising=False)
     mod._warned_once = False
     with caplog.at_level(logging.WARNING):
-        assert mod.load_credentials() is None
+        with pytest.raises(SyncTokenExpired):
+            mod.load_credentials()
     assert "No Google credentials found" in caplog.text
     caplog.clear()
     with caplog.at_level(logging.WARNING):
-        assert mod.load_credentials() is None
+        with pytest.raises(SyncTokenExpired):
+            mod.load_credentials()
     assert caplog.text == ""
 
 
@@ -81,5 +85,6 @@ def test_load_credentials_client_config(monkeypatch, tmp_path, caplog):
     monkeypatch.setattr(mod, "TOKEN_PATH", path, raising=False)
     mod._warned_once = False
     with caplog.at_level(logging.WARNING):
-        assert mod.load_credentials() is None
+        with pytest.raises(SyncTokenExpired):
+            mod.load_credentials()
     assert "client config" in caplog.text

--- a/tests/test_google_oauth_web.py
+++ b/tests/test_google_oauth_web.py
@@ -1,9 +1,11 @@
 import json
 import logging
 
+import pytest
 from flask import Flask
 
 from web.routes import google_oauth_web as mod
+from services.google.exceptions import SyncTokenExpired
 
 
 def make_app():
@@ -51,7 +53,8 @@ def test_load_credentials_missing_file(monkeypatch, tmp_path, caplog):
     missing = tmp_path / "missing.json"
     monkeypatch.setattr(mod, "TOKEN_PATH", missing, raising=False)
     with caplog.at_level(logging.WARNING):
-        assert mod.load_credentials() is None
+        with pytest.raises(SyncTokenExpired):
+            mod.load_credentials()
     assert "Token file not found" in caplog.text
 
 

--- a/web/auth/decorators.py
+++ b/web/auth/decorators.py
@@ -24,12 +24,10 @@ def login_required(view_func):
 
     @wraps(view_func)
     def wrapper(*args, **kwargs):
-        if not _agent().is_logged_in():
         if not _agent().is_logged_in() or "discord_user" not in session:
             flash(t("login_required", default="Login required."), "warning")
             return redirect(url_for("auth.login"))
-        else:
-            return view_func(*args, **kwargs)
+        return view_func(*args, **kwargs)
 
     return wrapper
 
@@ -39,7 +37,6 @@ def r3_required(view_func):
 
     @wraps(view_func)
     def wrapper(*args, **kwargs):
-        if not _agent().is_r3():
         if not _agent().is_r3() or session.get("discord_user", {}).get("role_level") not in [
             "R3",
             "R4",
@@ -47,8 +44,7 @@ def r3_required(view_func):
         ]:
             flash(t("member_only", default="Members only."))
             return redirect(url_for("auth.login"))
-        else:
-            return view_func(*args, **kwargs)
+        return view_func(*args, **kwargs)
 
     return wrapper
 
@@ -58,15 +54,13 @@ def r4_required(view_func):
 
     @wraps(view_func)
     def wrapper(*args, **kwargs):
-        if not _agent().is_r4():
         if not _agent().is_r4() or session.get("discord_user", {}).get("role_level") not in [
             "R4",
             "ADMIN",
         ]:
             flash(t("admin_only", default="Admins only."))
             return redirect(url_for("auth.login"))
-        else:
-            return view_func(*args, **kwargs)
+        return view_func(*args, **kwargs)
 
     return wrapper
 
@@ -76,11 +70,9 @@ def admin_required(view_func):
 
     @wraps(view_func)
     def wrapper(*args, **kwargs):
-        if not _agent().is_admin():
         if not _agent().is_admin() or session.get("discord_user", {}).get("role_level") != "ADMIN":
             flash(t("superuser_only", default="Superuser only."))
             return redirect(url_for("auth.login"))
-        else:
-            return view_func(*args, **kwargs)
+        return view_func(*args, **kwargs)
 
     return wrapper


### PR DESCRIPTION
## Summary
- add `SyncTokenExpired` exception for missing or invalid OAuth tokens
- raise and propagate this exception from Google auth helpers
- fix auth decorators' malformed conditionals

## Testing
- `python -m black --check services/__init__.py services/calendar_service.py services/google/auth.py services/google/calendar_sync.py web/routes/google_oauth_web.py tests/services/google/test_auth.py tests/services/google/test_sync.py tests/test_google_oauth_web.py web/auth/decorators.py`
- `flake8 services/__init__.py services/calendar_service.py services/google/auth.py services/google/calendar_sync.py web/routes/google_oauth_web.py tests/services/google/test_auth.py tests/services/google/test_sync.py tests/test_google_oauth_web.py web/auth/decorators.py`
- `pytest` *(fails: Module import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68981dcd7d588324894fd965a1d03a52