### PR TITLE
Refactor Google calendar configuration usage

### DIFF
--- a/services/calendar_service.py
+++ b/services/calendar_service.py
@@ -4,8 +4,7 @@ import os
 from datetime import date as date_type, datetime, timedelta, timezone
 from typing import Any, Iterable, Optional
 
-from flask import current_app
-from web import create_app
+from flask import current_app, has_app_context
 
 from discord.ext import tasks
 from googleapiclient.discovery import build
@@ -13,27 +12,12 @@ from googleapiclient.errors import HttpError
 from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorCollection
 from pymongo.errors import ConfigurationError
 
-from config import Config
 from crud import event_crud
 from services.google.auth import load_credentials
 from schemas.event_schema import EventModel
 from utils.time_utils import parse_calendar_datetime
 
 log = logging.getLogger(__name__)
-
-
-_app = None
-
-
-def _get_app():
-    """Return a Flask application instance."""
-    global _app
-    try:
-        return current_app._get_current_object()
-    except RuntimeError:
-        if _app is None:
-            _app = create_app()
-        return _app
 
 
 class SyncTokenExpired(Exception):
@@ -51,10 +35,19 @@ class CalendarService:
         events_collection: Optional[AsyncIOMotorCollection] = None,
         tokens_collection: Optional[AsyncIOMotorCollection] = None,
     ) -> None:
-        self.calendar_id = calendar_id or Config.GOOGLE_CALENDAR_ID
+        if calendar_id is None:
+            if has_app_context():
+                calendar_id = current_app.config.get("GOOGLE_CALENDAR_ID")
+            else:
+                calendar_id = os.getenv("GOOGLE_CALENDAR_ID")
+        self.calendar_id = calendar_id
         self.service: Any | None = None
-        self.warned_missing_creds = False
-        uri = mongo_uri or Config.MONGODB_URI or "mongodb://localhost:27017/furdb"
+        uri = mongo_uri
+        if uri is None:
+            if has_app_context():
+                uri = current_app.config.get("MONGODB_URI")
+            if not uri:
+                uri = os.getenv("MONGODB_URI", "mongodb://localhost:27017/furdb")
         if events_collection is not None and tokens_collection is not None:
             self.client = None
             self.events = events_collection
@@ -75,16 +68,9 @@ class CalendarService:
     def _build_service(self) -> None:
         if self.service:
             return
-        app = _get_app()
-        with app.app_context():
-            creds = load_credentials()
+        creds = load_credentials()
         if not creds:
-            if not self.warned_missing_creds:
-                log.warning("Google credentials missing – cannot sync")
-                self.warned_missing_creds = True
-            self.service = None
-            return
-        self.warned_missing_creds = False
+            raise SyncTokenExpired("Google credentials missing or invalid")
         self.service = build(
             "calendar",
             "v3",
@@ -94,9 +80,6 @@ class CalendarService:
 
     async def _api_list(self, params: dict) -> dict:
         self._build_service()
-        if not self.service:
-            log.warning("Calendar service not initialized – skipping")
-            return {}
         return await asyncio.to_thread(self.service.events().list(**params).execute)
 
     # ------------------------------------------------------------------

--- a/tests/services/google/test_calendar_sync.py
+++ b/tests/services/google/test_calendar_sync.py
@@ -41,13 +41,28 @@ def test_fetch_upcoming_events_missing_credentials(monkeypatch):
     assert mod.fetch_upcoming_events(service=None, calendar_id="cal") == []
 
 
-def test_fetch_upcoming_events_missing_calendar_id(monkeypatch):
+def test_fetch_upcoming_events_missing_calendar_id(monkeypatch, app):
     service = MagicMock()
-    monkeypatch.setattr(mod.Config, "GOOGLE_CALENDAR_ID", None)
-    assert mod.fetch_upcoming_events(service=service, calendar_id=None) == []
+    with app.app_context():
+        app.config["GOOGLE_CALENDAR_ID"] = None
+        assert mod.fetch_upcoming_events(service=service, calendar_id=None) == []
 
 
-def test_sync_to_mongodb(monkeypatch):
+def test_list_upcoming_events(monkeypatch, app):
+    events = [{"id": "1"}]
+
+    def fake_fetch(*, time_min, max_results, **kwargs):
+        assert isinstance(time_min, datetime)
+        assert max_results == 5
+        return events
+
+    monkeypatch.setattr(mod, "fetch_upcoming_events", fake_fetch)
+    with app.app_context():
+        result = mod.list_upcoming_events(max_results=5)
+    assert result == events
+
+
+def test_sync_to_mongodb(monkeypatch, app):
     service = object()
     event = {
         "id": "g1",
@@ -61,12 +76,18 @@ def test_sync_to_mongodb(monkeypatch):
     collection = MagicMock()
     monkeypatch.setattr(mod, "get_collection", lambda name: collection)
 
-    count = mod.sync_to_mongodb(collection="events")
+    with app.app_context():
+        count = mod.sync_to_mongodb(collection="events")
 
     assert count == 1
     collection.update_one.assert_called_once_with({"google_id": "g1"}, ANY, upsert=True)
 
 
-def test_sync_to_mongodb_no_service(monkeypatch):
-    monkeypatch.setattr(mod, "get_calendar_service", lambda: None)
-    assert mod.sync_to_mongodb(collection="events") == 0
+def test_sync_to_mongodb_no_service(monkeypatch, app):
+    def raise_exc():
+        raise mod.SyncTokenExpired
+
+    monkeypatch.setattr(mod, "get_calendar_service", raise_exc)
+    with app.app_context():
+        with pytest.raises(mod.SyncTokenExpired):
+            mod.sync_to_mongodb(collection="events")

--- a/web/auth/decorators.py
+++ b/web/auth/decorators.py
@@ -24,12 +24,10 @@ def login_required(view_func):
 
     @wraps(view_func)
     def wrapper(*args, **kwargs):
-        if not _agent().is_logged_in():
         if not _agent().is_logged_in() or "discord_user" not in session:
             flash(t("login_required", default="Login required."), "warning")
             return redirect(url_for("auth.login"))
-        else:
-            return view_func(*args, **kwargs)
+        return view_func(*args, **kwargs)
 
     return wrapper
 
@@ -39,7 +37,6 @@ def r3_required(view_func):
 
     @wraps(view_func)
     def wrapper(*args, **kwargs):
-        if not _agent().is_r3():
         if not _agent().is_r3() or session.get("discord_user", {}).get("role_level") not in [
             "R3",
             "R4",
@@ -47,8 +44,7 @@ def r3_required(view_func):
         ]:
             flash(t("member_only", default="Members only."))
             return redirect(url_for("auth.login"))
-        else:
-            return view_func(*args, **kwargs)
+        return view_func(*args, **kwargs)
 
     return wrapper
 
@@ -58,15 +54,13 @@ def r4_required(view_func):
 
     @wraps(view_func)
     def wrapper(*args, **kwargs):
-        if not _agent().is_r4():
         if not _agent().is_r4() or session.get("discord_user", {}).get("role_level") not in [
             "R4",
             "ADMIN",
         ]:
             flash(t("admin_only", default="Admins only."))
             return redirect(url_for("auth.login"))
-        else:
-            return view_func(*args, **kwargs)
+        return view_func(*args, **kwargs)
 
     return wrapper
 
@@ -76,11 +70,9 @@ def admin_required(view_func):
 
     @wraps(view_func)
     def wrapper(*args, **kwargs):
-        if not _agent().is_admin():
         if not _agent().is_admin() or session.get("discord_user", {}).get("role_level") != "ADMIN":
             flash(t("superuser_only", default="Superuser only."))
             return redirect(url_for("auth.login"))
-        else:
-            return view_func(*args, **kwargs)
+        return view_func(*args, **kwargs)
 
     return wrapper


### PR DESCRIPTION
## Summary
- build Google Calendar client lazily and raise `SyncTokenExpired` if credentials are missing
- drive calendar settings from `current_app.config`, expose `list_upcoming_events`, and exercise it via new tests
- start sync task within app context using configurable interval

## Testing
- `black --check services/google/sync_task.py services/calendar_service.py services/google/calendar_sync.py tests/services/google/test_sync.py tests/services/google/test_calendar_sync.py web/auth/decorators.py`
- `flake8 services/google/sync_task.py services/calendar_service.py services/google/calendar_sync.py tests/services/google/test_sync.py tests/services/google/test_calendar_sync.py web/auth/decorators.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask_socketio')*

------
https://chatgpt.com/codex/tasks/task_e_68981db364a4832497ab131424cfe062