### PR TITLE
Raise SyncTokenExpired on missing Google token

### DIFF
--- a/tests/services/google/test_calendar_sync.py
+++ b/tests/services/google/test_calendar_sync.py
@@ -1,6 +1,7 @@
 import logging
 from unittest.mock import MagicMock
 
+import pytest
 import services.google.calendar_sync as mod
 
 
@@ -40,11 +41,13 @@ def test_load_credentials_warns_once(monkeypatch, tmp_path, caplog):
     monkeypatch.setattr(mod, "TOKEN_PATH", missing, raising=False)
     mod._warned_once = False
     with caplog.at_level(logging.WARNING):
-        assert mod.load_credentials() is None
+        with pytest.raises(mod.SyncTokenExpired):
+            mod.load_credentials()
     assert "No Google credentials found" in caplog.text
     caplog.clear()
     with caplog.at_level(logging.WARNING):
-        assert mod.load_credentials() is None
+        with pytest.raises(mod.SyncTokenExpired):
+            mod.load_credentials()
     assert caplog.text == ""
 
 
@@ -56,5 +59,6 @@ def test_load_credentials_client_config(monkeypatch, tmp_path, caplog):
     monkeypatch.setattr(mod, "TOKEN_PATH", path, raising=False)
     mod._warned_once = False
     with caplog.at_level(logging.WARNING):
-        assert mod.load_credentials() is None
+        with pytest.raises(mod.SyncTokenExpired):
+            mod.load_credentials()
     assert "client config" in caplog.text

--- a/tests/test_google_oauth_web.py
+++ b/tests/test_google_oauth_web.py
@@ -1,6 +1,7 @@
 import json
 import logging
 
+import pytest
 from flask import Flask
 
 from web.routes import google_oauth_web as mod
@@ -51,7 +52,8 @@ def test_load_credentials_missing_file(monkeypatch, tmp_path, caplog):
     missing = tmp_path / "missing.json"
     monkeypatch.setattr(mod, "TOKEN_PATH", missing, raising=False)
     with caplog.at_level(logging.WARNING):
-        assert mod.load_credentials() is None
+        with pytest.raises(mod.SyncTokenExpired):
+            mod.load_credentials()
     assert "Token file not found" in caplog.text
 
 


### PR DESCRIPTION
## Summary
- add `SyncTokenExpired` exception to signal missing or invalid Google OAuth tokens
- propagate exception from helper functions so callers can trigger refresh logic
- adjust tests for new error handling

## Testing
- `black --check .` *(fails: Cannot parse for target version Python 3.10: web/auth/decorators.py)*
- `flake8`
- `pytest` *(fails: IndentationError: unexpected indent in web/auth/decorators.py)*

------
https://chatgpt.com/codex/tasks/task_e_6898269228f4832482dd1de192dc7692