### PR TITLE
Check for Google token file before building calendar service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,7 +65,7 @@ GOOGLE_SCOPES=https://www.googleapis.com/auth/calendar.readonly    # Grundlegend
 GOOGLE_CALENDAR_SCOPES=https://www.googleapis.com/auth/calendar    # Schreibender Zugriff
 GOOGLE_CALENDAR_ID=                             # z.B. <id>@group.calendar.google.com
 GOOGLE_SYNC_INTERVAL_MINUTES=2                  # Intervall in Minuten
-GOOGLE_TOKEN_STORAGE_PATH=tokens/google_token.json           # Speicherort des Tokens
+GOOGLE_TOKEN_STORAGE_PATH=tokens/google_token.json           # Pfad zum gespeicherten Google OAuth-Token (mit services/google/oauth_setup.py erzeugen)
 GOOGLE_CREDENTIALS_FILE=tokens/google_token.json             # Pfad zum OAuth-Token
 
 # === OpenAI & Codex ===

--- a/services/google/calendar_sync.py
+++ b/services/google/calendar_sync.py
@@ -189,6 +189,10 @@ def get_service(settings: CalendarSettings | None = None) -> Any | None:
 
     settings = settings or CalendarSettings()
     token_path = settings.token_path
+    setup_hint = "Run services/google/oauth_setup.py to create tokens."
+    if not token_path.exists():
+        logger.warning("Google credentials not found at %s. %s", token_path, setup_hint)
+        raise SyncTokenExpired(f"Google credentials not found at {token_path}. {setup_hint}")
     if token_path in _service_cache:
         return _service_cache[token_path]
     creds = load_credentials(settings)


### PR DESCRIPTION
## Summary
- validate Google OAuth token file exists before constructing calendar services
- raise `SyncTokenExpired` with guidance to run `services/google/oauth_setup.py` when token missing
- document `GOOGLE_TOKEN_STORAGE_PATH` in `.env.example`

## Testing
- `black --check .`
- `flake8`
- `pytest` *(fails: missing modules such as flask_socketio, pydantic, prometheus_client; 9 errors total)*


------
https://chatgpt.com/codex/tasks/task_e_68989647a57483249d0e9b5a6ffbabfa