### PR TITLE
Centralize Google Calendar environment config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,8 +65,8 @@ GOOGLE_SCOPES=https://www.googleapis.com/auth/calendar.readonly    # Grundlegend
 GOOGLE_CALENDAR_SCOPES=https://www.googleapis.com/auth/calendar    # Schreibender Zugriff
 GOOGLE_CALENDAR_ID=                             # z.B. <id>@group.calendar.google.com
 GOOGLE_SYNC_INTERVAL_MINUTES=2                  # Intervall in Minuten
-GOOGLE_TOKEN_STORAGE_PATH=tokens/google_token.json           # Pfad zum gespeicherten Google OAuth-Token (mit services/google/oauth_setup.py erzeugen)
-GOOGLE_CREDENTIALS_FILE=tokens/google_token.json             # Pfad zum OAuth-Token
+GOOGLE_TOKEN_STORAGE_PATH=tokens/google_token.json           # Pfad zum gespeicherten Google OAuth-Token (fällt zurück auf GOOGLE_CREDENTIALS_FILE bzw. /data/google_token.json)
+GOOGLE_CREDENTIALS_FILE=tokens/google_token.json             # Pfad zum OAuth-Token (Standard: /data/google_token.json)
 
 # === OpenAI & Codex ===
 OPENAI_API_KEY=                   # API-Schlüssel für OpenAI

--- a/services/calendar_service.py
+++ b/services/calendar_service.py
@@ -17,6 +17,7 @@ from services.google.calendar_sync import (
     load_credentials,
 )
 from schemas.event_schema import EventModel
+from utils.env_utils import get_google_calendar_settings
 from utils.time_utils import parse_calendar_datetime
 
 log = logging.getLogger(__name__)
@@ -39,16 +40,10 @@ class CalendarService:
         token_path: Optional[str] = None,
         scopes: Optional[list[str]] = None,
     ) -> None:
-        self.calendar_id = calendar_id or os.getenv("GOOGLE_CALENDAR_ID")
-        self.token_path = (
-            token_path
-            or os.getenv("GOOGLE_TOKEN_STORAGE_PATH")
-            or os.getenv(
-                "GOOGLE_CREDENTIALS_FILE",
-                "/data/google_token.json",
-            )
-        )
-        self.scopes = scopes or ["https://www.googleapis.com/auth/calendar.readonly"]
+        settings = get_google_calendar_settings()
+        self.calendar_id = calendar_id or settings.calendar_id
+        self.token_path = token_path or settings.token_path
+        self.scopes = scopes or settings.scopes
         self.service: Any | None = None
         uri = mongo_uri or os.getenv("MONGODB_URI", "mongodb://localhost:27017/furdb")
         if events_collection is not None and tokens_collection is not None:

--- a/services/google/auth.py
+++ b/services/google/auth.py
@@ -20,6 +20,8 @@ from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import Flow
 from googleapiclient.discovery import build
 
+from utils.env_utils import get_google_calendar_settings
+
 google_auth = Blueprint("google_auth", __name__)
 
 log = logging.getLogger(__name__)
@@ -41,7 +43,7 @@ def _cred_path() -> str:
         path = current_app.config.get("GOOGLE_CREDENTIALS_FILE")
         if path:
             return path
-    return os.environ.get("GOOGLE_CREDENTIALS_FILE", "/data/google_token.json")
+    return get_google_calendar_settings().credentials_file
 
 
 def _token_path() -> str:
@@ -59,7 +61,7 @@ def _token_path() -> str:
         path = current_app.config.get("GOOGLE_TOKEN_STORAGE_PATH")
         if path:
             return path
-    return os.environ.get("GOOGLE_TOKEN_STORAGE_PATH", _cred_path())
+    return get_google_calendar_settings().token_path
 
 
 def _client_config() -> dict[str, dict[str, Any]]:

--- a/services/google/calendar_sync.py
+++ b/services/google/calendar_sync.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -22,6 +21,7 @@ from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
 
+from utils.env_utils import get_google_calendar_settings
 from utils.time_utils import parse_calendar_datetime
 from pymongo import UpdateOne
 
@@ -61,11 +61,7 @@ _warned_once = False
 def _default_token_path() -> Path:
     """Return the default path for stored OAuth tokens."""
 
-    return Path(
-        os.getenv("GOOGLE_TOKEN_STORAGE_PATH")
-        or os.getenv("GOOGLE_CREDENTIALS_FILE")
-        or "/data/google_token.json"
-    )
+    return Path(get_google_calendar_settings().token_path)
 
 
 @dataclass
@@ -73,10 +69,8 @@ class CalendarSettings:
     """Runtime configuration for Google Calendar access."""
 
     token_path: Path = field(default_factory=_default_token_path)
-    calendar_id: str | None = os.getenv("GOOGLE_CALENDAR_ID")
-    scopes: list[str] = field(
-        default_factory=lambda: ["https://www.googleapis.com/auth/calendar.readonly"]
-    )
+    calendar_id: str | None = get_google_calendar_settings().calendar_id
+    scopes: list[str] = field(default_factory=lambda: get_google_calendar_settings().scopes)
 
 
 class SyncTokenExpired(Exception):

--- a/tests/utils/test_env_utils.py
+++ b/tests/utils/test_env_utils.py
@@ -1,0 +1,41 @@
+from utils.env_utils import get_google_calendar_settings, DEFAULT_TOKEN_PATH, DEFAULT_SCOPES
+
+
+def clear_env(monkeypatch):
+    for var in [
+        "GOOGLE_CALENDAR_ID",
+        "GOOGLE_TOKEN_STORAGE_PATH",
+        "GOOGLE_CREDENTIALS_FILE",
+        "GOOGLE_CALENDAR_SCOPES",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_defaults(monkeypatch):
+    clear_env(monkeypatch)
+    settings = get_google_calendar_settings()
+    assert settings.calendar_id is None
+    assert settings.token_path == DEFAULT_TOKEN_PATH
+    assert settings.credentials_file == DEFAULT_TOKEN_PATH
+    assert settings.scopes == DEFAULT_SCOPES
+
+
+def test_token_path_fallback(monkeypatch):
+    clear_env(monkeypatch)
+    monkeypatch.setenv("GOOGLE_CREDENTIALS_FILE", "/tmp/creds.json")
+    settings = get_google_calendar_settings()
+    assert settings.token_path == "/tmp/creds.json"
+    assert settings.credentials_file == "/tmp/creds.json"
+
+
+def test_overrides(monkeypatch):
+    clear_env(monkeypatch)
+    monkeypatch.setenv("GOOGLE_CALENDAR_ID", "abc")
+    monkeypatch.setenv("GOOGLE_TOKEN_STORAGE_PATH", "/tmp/token.json")
+    monkeypatch.setenv("GOOGLE_CREDENTIALS_FILE", "/tmp/creds.json")
+    monkeypatch.setenv("GOOGLE_CALENDAR_SCOPES", "s1,s2")
+    settings = get_google_calendar_settings()
+    assert settings.calendar_id == "abc"
+    assert settings.token_path == "/tmp/token.json"
+    assert settings.credentials_file == "/tmp/creds.json"
+    assert settings.scopes == ["s1", "s2"]

--- a/utils/env_utils.py
+++ b/utils/env_utils.py
@@ -1,0 +1,37 @@
+import os
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+DEFAULT_TOKEN_PATH = "/data/google_token.json"
+DEFAULT_SCOPES = ["https://www.googleapis.com/auth/calendar.readonly"]
+
+
+@dataclass
+class GoogleCalendarSettings:
+    """Environment driven configuration for Google Calendar access."""
+
+    calendar_id: Optional[str]
+    token_path: str = DEFAULT_TOKEN_PATH
+    credentials_file: str = DEFAULT_TOKEN_PATH
+    scopes: List[str] = field(default_factory=lambda: DEFAULT_SCOPES.copy())
+
+
+def get_google_calendar_settings() -> GoogleCalendarSettings:
+    """Retrieve Google Calendar configuration from environment variables.
+
+    Returns a :class:`GoogleCalendarSettings` instance with sensible defaults.
+    ``GOOGLE_TOKEN_STORAGE_PATH`` falls back to ``GOOGLE_CREDENTIALS_FILE``
+    which itself defaults to ``/data/google_token.json``.
+    ``GOOGLE_CALENDAR_SCOPES`` is parsed as a comma separated list.
+    """
+
+    credentials_file = os.getenv("GOOGLE_CREDENTIALS_FILE", DEFAULT_TOKEN_PATH)
+    token_path = os.getenv("GOOGLE_TOKEN_STORAGE_PATH", credentials_file)
+    scopes_env = os.getenv("GOOGLE_CALENDAR_SCOPES", ",".join(DEFAULT_SCOPES))
+    scopes = [s.strip() for s in scopes_env.split(",") if s.strip()]
+    return GoogleCalendarSettings(
+        calendar_id=os.getenv("GOOGLE_CALENDAR_ID"),
+        token_path=token_path,
+        credentials_file=credentials_file,
+        scopes=scopes,
+    )


### PR DESCRIPTION
## Summary
- add `get_google_calendar_settings` helper consolidating Google-related environment variables
- refactor calendar services to rely on the helper
- document Google env defaults in `.env.example`
- cover env helper with tests

## Testing
- `black --check .`
- `flake8`
- `pytest` *(fails: ModuleNotFoundError: No module named 'prometheus_client')*

------
https://chatgpt.com/codex/tasks/task_e_68989b4b07748324b1e26fe7ca390438