### PR TITLE
chore: update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,23 @@
 repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.7
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+      - id: ruff-format
   - repo: https://github.com/psf/black
-    rev: 23.11.0
+    rev: 24.4.2
     hooks:
       - id: black
         language_version: python3
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
     hooks:
-      - id: flake8
-  - repo: https://github.com/pre-commit/mirrors-pytest
-    rev: v7.4.3
+      - id: mypy
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.1
     hooks:
-      - id: pytest
+      - id: gitleaks
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0
     hooks:


### PR DESCRIPTION
## Summary
- add ruff, ruff-format, mypy, and gitleaks to pre-commit
- remove flake8 and pytest hooks now covered elsewhere

## Testing
- `black --check .` *(fails: 9 files would be reformatted, 4 files failed to reformat)*
- `flake8` *(fails: multiple undefined names and syntax errors)*
- `pytest -q` *(fails: numerous failing tests and errors)*
- `pre-commit run --all-files` *(fails: ruff, ruff-format, black, mypy, detect-secrets errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c1374a888324a1477fc8ea25c3cb